### PR TITLE
v0.6.0

### DIFF
--- a/src/WorkOS.net/Client/WorkOSClient.cs
+++ b/src/WorkOS.net/Client/WorkOSClient.cs
@@ -32,7 +32,7 @@
         /// <summary>
         /// Describes the .NET SDK version.
         /// </summary>
-        public static string SdkVersion => "0.3.0";
+        public static string SdkVersion => "0.6.0";
 
         /// <summary>
         /// Default timeout for HTTP requests.

--- a/src/WorkOS.net/WorkOS.net.csproj
+++ b/src/WorkOS.net/WorkOS.net.csproj
@@ -10,7 +10,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageId>WorkOS.net</PackageId>
-    <PackageTags>workos;sso;audit;trail</PackageTags>
+    <PackageTags>workos;sso;audit;trail;directory;sync;portal</PackageTags>
     <PackageProjectUrl>https://github.com/workos/workos-dotnet</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -19,8 +19,8 @@
     <SignAssembly>True</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.3.0</VersionPrefix>
-    <Version>0.3.0</Version>
+    <VersionPrefix>0.6.0</VersionPrefix>
+    <Version>0.6.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
0.4.0 and 0.5.0 changes from our other SDKs were included when bootstrapping Audit Trail and Directory Sync, so jumping those versions to keep Portal version in sync.