### PR TITLE
Expose `connection_id` on Profile Objects

### DIFF
--- a/src/WorkOS.net/Client/WorkOSClient.cs
+++ b/src/WorkOS.net/Client/WorkOSClient.cs
@@ -32,7 +32,7 @@
         /// <summary>
         /// Describes the .NET SDK version.
         /// </summary>
-        public static string SdkVersion => "0.7.0";
+        public static string SdkVersion => "0.8.0";
 
         /// <summary>
         /// Default timeout for HTTP requests.

--- a/src/WorkOS.net/Services/SSO/Entities/Profile.cs
+++ b/src/WorkOS.net/Services/SSO/Entities/Profile.cs
@@ -21,6 +21,12 @@
         public string IdpId { get; set; }
 
         /// <summary>
+        /// The identifier for the Connection associated with the Profile.
+        /// </summary>
+        [JsonProperty("connection_id")]
+        public string ConnectionId { get; set; }
+
+        /// <summary>
         /// The Connection type associated with the Profile.
         /// </summary>
         [JsonProperty("connection_type")]

--- a/src/WorkOS.net/Services/SSO/Entities/Profile.cs
+++ b/src/WorkOS.net/Services/SSO/Entities/Profile.cs
@@ -21,7 +21,7 @@
         public string IdpId { get; set; }
 
         /// <summary>
-        /// The identifier for the Connection associated with the Profile.
+        /// The identifier for the <see cref="Connection"/> associated with the Profile.
         /// </summary>
         [JsonProperty("connection_id")]
         public string ConnectionId { get; set; }

--- a/src/WorkOS.net/WorkOS.net.csproj
+++ b/src/WorkOS.net/WorkOS.net.csproj
@@ -19,8 +19,8 @@
     <SignAssembly>True</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.7.0</VersionPrefix>
-    <Version>0.7.0</Version>
+    <VersionPrefix>0.8.0</VersionPrefix>
+    <Version>0.8.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
+++ b/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
@@ -102,6 +102,7 @@
             {
                 Id = "profile_0",
                 IdpId = "123",
+                ConnectionId = "conn_123",
                 ConnectionType = ConnectionType.OktaSAML,
                 Email = "rick@sanchez.com",
                 FirstName = "Rick",
@@ -148,6 +149,7 @@
             {
                 Id = "profile_0",
                 IdpId = "123",
+                ConnectionId = "conn_123",
                 ConnectionType = ConnectionType.OktaSAML,
                 Email = "rick@sanchez.com",
                 FirstName = "Rick",


### PR DESCRIPTION
This PR introduces the following changes:

* Passes the `connection_id` Profile object attribute through to the SDK. We currently expose `connection_id` via the `/sso/token` API endpoint.
* Updates the SDK version to `0.8.0`.