### PR TITLE
Update Available Connection Types

### DIFF
--- a/src/WorkOS.net/Client/WorkOSClient.cs
+++ b/src/WorkOS.net/Client/WorkOSClient.cs
@@ -32,7 +32,7 @@
         /// <summary>
         /// Describes the .NET SDK version.
         /// </summary>
-        public static string SdkVersion => "0.8.0";
+        public static string SdkVersion => "0.8.1";
 
         /// <summary>
         /// Default timeout for HTTP requests.

--- a/src/WorkOS.net/Services/SSO/Enums/ConnectionType.cs
+++ b/src/WorkOS.net/Services/SSO/Enums/ConnectionType.cs
@@ -16,17 +16,29 @@
         [EnumMember(Value = "AzureSAML")]
         AzureSAML,
 
+        [EnumMember(Value = "GenericOIDC")]
+        GenericOIDC,
+
         [EnumMember(Value = "GenericSAML")]
         GenericSAML,
 
         [EnumMember(Value = "GoogleOAuth")]
         GoogleOAuth,
 
+        [EnumMember(Value = "MagicLink")]
+        MagicLink,
+
         [EnumMember(Value = "OktaSAML")]
         OktaSAML,
 
         [EnumMember(Value = "OneLoginSAML")]
         OneLoginSAML,
+
+        [EnumMember(Value = "PingFederateSAML")]
+        PingFederateSAML,
+
+        [EnumMember(Value = "PingOneSAML")]
+        PingOneSAML,
 
         [EnumMember(Value = "VMwareSAML")]
         VMwareSAML,

--- a/src/WorkOS.net/WorkOS.net.csproj
+++ b/src/WorkOS.net/WorkOS.net.csproj
@@ -19,8 +19,8 @@
     <SignAssembly>True</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.8.0</VersionPrefix>
-    <Version>0.8.0</Version>
+    <VersionPrefix>0.8.1</VersionPrefix>
+    <Version>0.8.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR introduces the following changes:

* Updates `ConnectionType` to reflect all Connection Types currently available in GA.
* Updates the SDK version to `0.8.1`.