### PR TITLE
version bump to 0.8.2

### DIFF
--- a/src/WorkOS.net/Client/WorkOSClient.cs
+++ b/src/WorkOS.net/Client/WorkOSClient.cs
@@ -32,7 +32,7 @@
         /// <summary>
         /// Describes the .NET SDK version.
         /// </summary>
-        public static string SdkVersion => "0.8.1";
+        public static string SdkVersion => "0.8.2";
 
         /// <summary>
         /// Default timeout for HTTP requests.

--- a/src/WorkOS.net/WorkOS.net.csproj
+++ b/src/WorkOS.net/WorkOS.net.csproj
@@ -19,8 +19,8 @@
     <SignAssembly>True</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.8.1</VersionPrefix>
-    <Version>0.8.1</Version>
+    <VersionPrefix>0.8.2</VersionPrefix>
+    <Version>0.8.2</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bump SDK version to 0.8.2, including:

- Support for a redirect_uri option when creating Passwordless Sessions