### PR TITLE
Add `GET /connections/:id`

### DIFF
--- a/src/WorkOS.net/Services/SSO/SSOService.cs
+++ b/src/WorkOS.net/Services/SSO/SSOService.cs
@@ -160,5 +160,40 @@
 
             return await this.Client.MakeAPIRequestAsync<WorkOSList<Connection>>(request, cancellationToken);
         }
+
+        /// <summary>
+        /// Gets a Connection.
+        /// </summary>
+        /// <param name="id">Connection unique identifier.</param>
+        /// <returns>A WorkOS Connection record.</returns>
+        public Connection GetConnection(string id)
+        {
+            var request = new WorkOSRequest
+            {
+                Method = HttpMethod.Get,
+                Path = $"/connections/{id}",
+            };
+
+            return this.Client.MakeAPIRequest<Connection>(request);
+        }
+
+        /// <summary>
+        /// Asynchronously gets a Connection.
+        /// </summary>
+        /// <param name="id">Connection unique identifier.</param>
+        /// <param name="cancellationToken">
+        /// An optional token to cancel the request.
+        /// </param>
+        /// <returns>A Task wrapping a WorkOS Connection record.</returns>
+        public async Task<Connection> GetConnectionAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var request = new WorkOSRequest
+            {
+                Method = HttpMethod.Get,
+                Path = $"/connections/{id}",
+            };
+
+            return await this.Client.MakeAPIRequestAsync<Connection>(request, cancellationToken);
+        }
     }
 }

--- a/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
+++ b/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
@@ -343,5 +343,43 @@
                 JsonConvert.SerializeObject(mockResponse),
                 JsonConvert.SerializeObject(response));
         }
+
+        [Fact]
+        public void TestGetConnection()
+        {
+            this.httpMock.MockResponse(
+                HttpMethod.Get,
+                $"/connections/{this.mockConnection.Id}",
+                HttpStatusCode.OK,
+                RequestUtilities.ToJsonString(this.mockConnection));
+
+            var response = this.service.GetConnection(this.mockConnection.Id);
+
+            this.httpMock.AssertRequestWasMade(
+                HttpMethod.Get,
+                $"/connections/{this.mockConnection.Id}");
+            Assert.Equal(
+                JsonConvert.SerializeObject(this.mockConnection),
+                JsonConvert.SerializeObject(response));
+        }
+
+        [Fact]
+        public async void TestGetConnectionAsync()
+        {
+            this.httpMock.MockResponse(
+                HttpMethod.Get,
+                $"/connections/{this.mockConnection.Id}",
+                HttpStatusCode.OK,
+                RequestUtilities.ToJsonString(this.mockConnection));
+
+            var response = await this.service.GetConnectionAsync(this.mockConnection.Id);
+
+            this.httpMock.AssertRequestWasMade(
+                HttpMethod.Get,
+                $"/connections/{this.mockConnection.Id}");
+            Assert.Equal(
+                JsonConvert.SerializeObject(this.mockConnection),
+                JsonConvert.SerializeObject(response));
+        }
     }
 }


### PR DESCRIPTION
This PR introduces the following changes:

- Adds functionality to retrieve a single Connection using the WorkOS SSO REST API