### PR TITLE
Add `DELETE /connections/:id`

### DIFF
--- a/src/WorkOS.net/Services/SSO/SSOService.cs
+++ b/src/WorkOS.net/Services/SSO/SSOService.cs
@@ -195,5 +195,40 @@
 
             return await this.Client.MakeAPIRequestAsync<Connection>(request, cancellationToken);
         }
+
+        /// <summary>
+        /// Deletes a Connection.
+        /// </summary>
+        /// <param name="id">Connection unique identifier.</param>
+        /// <returns>A deleted WorkOS Connection record.</returns>
+        public Connection DeleteConnection(string id)
+        {
+            var request = new WorkOSRequest
+            {
+                Method = HttpMethod.Delete,
+                Path = $"/connections/{id}",
+            };
+
+            return this.Client.MakeAPIRequest<Connection>(request);
+        }
+
+        /// <summary>
+        /// Asynchronously deletes a Connection.
+        /// </summary>
+        /// <param name="id">Connection unique identifier.</param>
+        /// <param name="cancellationToken">
+        /// An optional token to cancel the request.
+        /// </param>
+        /// <returns>A Task wrapping a deleted WorkOS Connection record.</returns>
+        public async Task<Connection> DeleteConnectionAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var request = new WorkOSRequest
+            {
+                Method = HttpMethod.Delete,
+                Path = $"/connections/{id}",
+            };
+
+            return await this.Client.MakeAPIRequestAsync<Connection>(request, cancellationToken);
+        }
     }
 }

--- a/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
+++ b/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
@@ -381,41 +381,5 @@
                 JsonConvert.SerializeObject(this.mockConnection),
                 JsonConvert.SerializeObject(response));
         }
-
-        [Fact]
-        public void TestDeleteConnection()
-        {
-            this.httpMock.MockResponse(
-                HttpMethod.Delete,
-                $"/connections/{this.mockConnection.Id}",
-                HttpStatusCode.OK);
-
-            var response = this.service.DeleteConnection(this.mockConnection.Id);
-
-            this.httpMock.AssertRequestWasMade(
-                HttpMethod.Delete,
-                $"/connections/{this.mockConnection.Id}");
-            Assert.Equal(
-                HttpStatusCode.OK,
-                JsonConvert.SerializeObject(response));
-        }
-
-        [Fact]
-        public async void TestDeleteConnectionAsync()
-        {
-            this.httpMock.MockResponse(
-                HttpMethod.Delete,
-                $"/connections/{this.mockConnection.Id}",
-                HttpStatusCode.OK);
-
-            var response = await this.service.DeleteConnectionAsync(this.mockConnection.Id);
-
-            this.httpMock.AssertRequestWasMade(
-                HttpMethod.Delete,
-                $"/connections/{this.mockConnection.Id}");
-            Assert.Equal(
-                HttpStatusCode.OK,
-                JsonConvert.SerializeObject(response));
-        }
     }
 }

--- a/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
+++ b/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
@@ -381,5 +381,41 @@
                 JsonConvert.SerializeObject(this.mockConnection),
                 JsonConvert.SerializeObject(response));
         }
+
+        [Fact]
+        public void TestDeleteConnection()
+        {
+            this.httpMock.MockResponse(
+                HttpMethod.Delete,
+                $"/connections/{this.mockConnection.Id}",
+                HttpStatusCode.OK);
+
+            var response = this.service.DeleteConnection(this.mockConnection.Id);
+
+            this.httpMock.AssertRequestWasMade(
+                HttpMethod.Delete,
+                $"/connections/{this.mockConnection.Id}");
+            Assert.Equal(
+                HttpStatusCode.OK,
+                JsonConvert.SerializeObject(response));
+        }
+
+        [Fact]
+        public async void TestDeleteConnectionAsync()
+        {
+            this.httpMock.MockResponse(
+                HttpMethod.Delete,
+                $"/connections/{this.mockConnection.Id}",
+                HttpStatusCode.OK);
+
+            var response = await this.service.DeleteConnectionAsync(this.mockConnection.Id);
+
+            this.httpMock.AssertRequestWasMade(
+                HttpMethod.Delete,
+                $"/connections/{this.mockConnection.Id}");
+            Assert.Equal(
+                HttpStatusCode.OK,
+                JsonConvert.SerializeObject(response));
+        }
     }
 }


### PR DESCRIPTION
This PR introduces the following changes:

- Adds functionality to delete a single Connection using the WorkOS SSO REST API