### PR TITLE
Remove `BearerToken` from `Directory`

### DIFF
--- a/src/WorkOS.net/Services/DirectorySync/Entities/Directory.cs
+++ b/src/WorkOS.net/Services/DirectorySync/Entities/Directory.cs
@@ -49,12 +49,6 @@
         public string ExternalKey { get; set; }
 
         /// <summary>
-        /// Bearer Token used to authenticate requests.
-        /// </summary>
-        [JsonProperty("bearer_token")]
-        public string BearerToken { get; set; }
-
-        /// <summary>
         /// Identifier for the Directory's Environment.
         /// </summary>
         [JsonProperty("environment_id")]


### PR DESCRIPTION
Remove the `BearerToken` property from the `Directory`, since soon the API won't return it anymore.

Resolves SDK-38.