### PR TITLE
Add `OrganizationId` Option to `ListConnections`

### DIFF
--- a/src/WorkOS.net/Services/SSO/_interfaces/ListConnectionsOptions.cs
+++ b/src/WorkOS.net/Services/SSO/_interfaces/ListConnectionsOptions.cs
@@ -20,7 +20,7 @@ namespace WorkOS
         public string ConnectionType { get; set; }
 
         /// <summary>
-        /// // Organization ID of the <see cref="Connection"/>(s). Can be empty.
+        /// Organization ID of the <see cref="Connection"/>(s). Can be empty.
         /// </summary>
         [JsonProperty("organization_id")]
         public string OrganizationId { get; set; }

--- a/src/WorkOS.net/Services/SSO/_interfaces/ListConnectionsOptions.cs
+++ b/src/WorkOS.net/Services/SSO/_interfaces/ListConnectionsOptions.cs
@@ -18,5 +18,11 @@ namespace WorkOS
         /// </summary>
         [JsonProperty("connection_type")]
         public string ConnectionType { get; set; }
+
+        /// <summary>
+        /// // Organization ID of the <see cref="Connection"/>(s). Can be empty.
+        /// </summary>
+        [JsonProperty("organization_id")]
+        public string OrganizationId { get; set; }
     }
 }


### PR DESCRIPTION
This PR introduces the following changes:

- Adds support for an `OrganizationId` option to the `ListConnections` function. Allows for retrieving a list of all Connections associated with the given `OrganizationId`.