### PR TITLE
Add `InvalidCredentials` to `DirectoryState` Enum

### DIFF
--- a/src/WorkOS.net/Services/DirectorySync/Enums/DirectoryState.cs
+++ b/src/WorkOS.net/Services/DirectorySync/Enums/DirectoryState.cs
@@ -15,5 +15,8 @@
 
         [EnumMember(Value = "unlinked")]
         Unlinked,
+
+        [EnumMember(Value = "invalid_credentials")]
+        InvalidCredentials,
     }
 }


### PR DESCRIPTION
This PR introduces the following changes:

- Adds `InvalidCredentials` as a possible value for the `DirectoryState` enum. This reflects the most up-to-date, available values for the Directory state enum provided by the WorkOS API.