### PR TITLE
Remove all synchronous methods

### DIFF
--- a/src/WorkOS.net/Client/WorkOSClient.cs
+++ b/src/WorkOS.net/Client/WorkOSClient.cs
@@ -76,21 +76,9 @@
         /// </summary>
         /// <typeparam name="T">The return type from the request.</typeparam>
         /// <param name="request">The request to make to the WorkOS API.</param>
-        /// <returns>The response object.</returns>
-        public T MakeAPIRequest<T>(WorkOSRequest request)
-        {
-            return this.MakeAPIRequestAsync<T>(request)
-                .ConfigureAwait(false).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Makes a request to the WorkOS API asynchronously.
-        /// </summary>
-        /// <typeparam name="T">The return type from the request.</typeparam>
-        /// <param name="request">The request to make to the WorkOS API.</param>
         /// <param name="cancellationToken">A token used to cancel the request.</param>
-        /// <returns>A Task wrapping the response.</returns>
-        public async Task<T> MakeAPIRequestAsync<T>(
+        /// <returns>The response from the WorkOS API.</returns>
+        public async Task<T> MakeAPIRequest<T>(
             WorkOSRequest request,
             CancellationToken cancellationToken = default)
         {

--- a/src/WorkOS.net/Services/AuditTrail/AuditTrailService.cs
+++ b/src/WorkOS.net/Services/AuditTrail/AuditTrailService.cs
@@ -28,41 +28,15 @@
         }
 
         /// <summary>
-        /// Creates an Audit Trail Event.
-        /// </summary>
-        /// <param name="options">Options representing an Event.</param>
-        /// <param name="idempotencyKey">An optional idempotency key.</param>
-        /// <returns>True if successful.</returns>
-        public bool CreateEvent(CreateEventOptions options, string idempotencyKey = null)
-        {
-            var request = new WorkOSRequest
-            {
-                Options = options,
-                Method = HttpMethod.Post,
-                Path = "/events",
-            };
-            if (idempotencyKey != null)
-            {
-                request.WorkOSHeaders = new Dictionary<string, string>
-                {
-                    { "Idempotency-Key", idempotencyKey },
-                };
-            }
-
-            this.Client.MakeAPIRequest<object>(request);
-            return true;
-        }
-
-        /// <summary>
-        /// Asynchronously creates an Audit Trail event.
+        /// Creates an Audit Trail event.
         /// </summary>
         /// <param name="options">Options representing an Event.</param>
         /// <param name="idempotencyKey">An optional idempotency key.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping True if successful.</returns>
-        public async Task<bool> CreateEventAsync(
+        /// <returns>True if successful.</returns>
+        public async Task<bool> CreateEvent(
             CreateEventOptions options,
             string idempotencyKey = null,
             CancellationToken cancellationToken = default)
@@ -81,7 +55,7 @@
                 };
             }
 
-            await this.Client.MakeAPIRequestAsync<object>(request, cancellationToken);
+            await this.Client.MakeAPIRequest<object>(request, cancellationToken);
             return true;
         }
 
@@ -89,28 +63,11 @@
         /// Fetches a list of Audit Trail Events.
         /// </summary>
         /// <param name="options">Filter options when searching for events.</param>
-        /// <returns>A paginated list of Audit Trail Events.</returns>
-        public WorkOSList<Event> ListEvents(ListEventsOptions options = null)
-        {
-            var request = new WorkOSRequest
-            {
-                Options = options,
-                Method = HttpMethod.Get,
-                Path = "/events",
-            };
-
-            return this.Client.MakeAPIRequest<WorkOSList<Event>>(request);
-        }
-
-        /// <summary>
-        /// Asynchronously fetches a list of Audit Trail Events.
-        /// </summary>
-        /// <param name="options">Filter options when searching for events.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
         /// <returns>A paginated list of Audit Trail Events.</returns>
-        public async Task<WorkOSList<Event>> ListEventsAsync(
+        public async Task<WorkOSList<Event>> ListEvents(
             ListEventsOptions options = null,
             CancellationToken cancellationToken = default)
         {
@@ -121,7 +78,7 @@
                 Path = "/events",
             };
 
-            return await this.Client.MakeAPIRequestAsync<WorkOSList<Event>>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<WorkOSList<Event>>(request, cancellationToken);
         }
     }
 }

--- a/src/WorkOS.net/Services/DirectorySync/DirectorySyncService.cs
+++ b/src/WorkOS.net/Services/DirectorySync/DirectorySyncService.cs
@@ -30,28 +30,11 @@
         /// Fetches a list of Directories.
         /// </summary>
         /// <param name="options">Filter options when searching for Directories.</param>
-        /// <returns>A paginated list of Directories.</returns>
-        public WorkOSList<Directory> ListDirectories(ListDirectoriesOptions options = null)
-        {
-            var request = new WorkOSRequest
-            {
-                Options = options,
-                Method = HttpMethod.Get,
-                Path = "/directories",
-            };
-
-            return this.Client.MakeAPIRequest<WorkOSList<Directory>>(request);
-        }
-
-        /// <summary>
-        /// Asynchronously fetches a list of Directories.
-        /// </summary>
-        /// <param name="options">Filter options when searching for Directories.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping a paginated list of Directories.</returns>
-        public async Task<WorkOSList<Directory>> ListDirectoriesAsync(
+        /// <returns>A paginated list of Directories.</returns>
+        public async Task<WorkOSList<Directory>> ListDirectories(
             ListDirectoriesOptions options = null,
             CancellationToken cancellationToken = default)
         {
@@ -62,35 +45,18 @@
                 Path = "/directories",
             };
 
-            return await this.Client.MakeAPIRequestAsync<WorkOSList<Directory>>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<WorkOSList<Directory>>(request, cancellationToken);
         }
 
         /// <summary>
         /// Fetches a list of Directory Users.
         /// </summary>
         /// <param name="options">Filter options when searching for Directory Users.</param>
-        /// <returns>A paginated list of Directory Users.</returns>
-        public WorkOSList<User> ListUsers(ListUsersOptions options)
-        {
-            var request = new WorkOSRequest
-            {
-                Options = options,
-                Method = HttpMethod.Get,
-                Path = "/directory_users",
-            };
-
-            return this.Client.MakeAPIRequest<WorkOSList<User>>(request);
-        }
-
-        /// <summary>
-        /// Asynchronously fetches a list of Directory Users.
-        /// </summary>
-        /// <param name="options">Filter options when searching for Directory Users.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping a paginated list of Directory Users.</returns>
-        public async Task<WorkOSList<User>> ListUsersAsync(
+        /// <returns>A paginated list of Directory Users.</returns>
+        public async Task<WorkOSList<User>> ListUsers(
             ListUsersOptions options,
             CancellationToken cancellationToken = default)
         {
@@ -101,34 +67,18 @@
                 Path = "/directory_users",
             };
 
-            return await this.Client.MakeAPIRequestAsync<WorkOSList<User>>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<WorkOSList<User>>(request, cancellationToken);
         }
 
         /// <summary>
         /// Gets a provisioned User for a Directory.
         /// </summary>
         /// <param name="id">Directory User unique identifier.</param>
-        /// <returns>A WorkOS Directory User record.</returns>
-        public User GetUser(string id)
-        {
-            var request = new WorkOSRequest
-            {
-                Method = HttpMethod.Get,
-                Path = $"/directory_users/{id}",
-            };
-
-            return this.Client.MakeAPIRequest<User>(request);
-        }
-
-        /// <summary>
-        /// Asynchronously gets a provisioned User for a Directory.
-        /// </summary>
-        /// <param name="id">Directory User unique identifier.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping a WorkOS Directory User record.</returns>
-        public async Task<User> GetUserAsync(string id, CancellationToken cancellationToken = default)
+        /// <returns>A WorkOS Directory User record.</returns>
+        public async Task<User> GetUser(string id, CancellationToken cancellationToken = default)
         {
             var request = new WorkOSRequest
             {
@@ -136,11 +86,11 @@
                 Path = $"/directory_users/{id}",
             };
 
-            return await this.Client.MakeAPIRequestAsync<User>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<User>(request, cancellationToken);
         }
 
         /// <summary>
-        /// Asynchronously deletes a Directory.
+        /// Deletes a Directory.
         /// </summary>
         /// <param name="id">Directory unique identifier.</param>
         /// <param name="cancellationToken">
@@ -155,35 +105,18 @@
                 Path = $"/directories/{id}",
             };
 
-            await this.Client.MakeAPIRequestAsync<Directory>(request, cancellationToken);
+            await this.Client.MakeAPIRequest<Directory>(request, cancellationToken);
         }
 
         /// <summary>
         /// Fetches a list of Directory Groups.
         /// </summary>
         /// <param name="options">Filter options when searching for Directory Groups.</param>
-        /// <returns>A paginated list of Directory Groups.</returns>
-        public WorkOSList<Group> ListGroups(ListGroupsOptions options)
-        {
-            var request = new WorkOSRequest
-            {
-                Options = options,
-                Method = HttpMethod.Get,
-                Path = "/directory_groups",
-            };
-
-            return this.Client.MakeAPIRequest<WorkOSList<Group>>(request);
-        }
-
-        /// <summary>
-        /// Asynchronously fetches a list of Directory Groups.
-        /// </summary>
-        /// <param name="options">Filter options when searching for Directory Groups.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping a paginated list of Directory Groups.</returns>
-        public async Task<WorkOSList<Group>> ListGroupsAsync(
+        /// <returns>A paginated list of Directory Groups.</returns>
+        public async Task<WorkOSList<Group>> ListGroups(
             ListGroupsOptions options,
             CancellationToken cancellationToken = default)
         {
@@ -194,34 +127,18 @@
                 Path = "/directory_groups",
             };
 
-            return await this.Client.MakeAPIRequestAsync<WorkOSList<Group>>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<WorkOSList<Group>>(request, cancellationToken);
         }
 
         /// <summary>
         /// Gets a provisioned Group for a Directory.
         /// </summary>
         /// <param name="id">Directory Group unique identifier.</param>
-        /// <returns>A WorkOS Directory Group record.</returns>
-        public Group GetGroup(string id)
-        {
-            var request = new WorkOSRequest
-            {
-                Method = HttpMethod.Get,
-                Path = $"/directory_groups/{id}",
-            };
-
-            return this.Client.MakeAPIRequest<Group>(request);
-        }
-
-        /// <summary>
-        /// Asynchronously gets a provisioned Group for a Directory.
-        /// </summary>
-        /// <param name="id">Directory Group unique identifier.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping a WorkOS Directory Group record.</returns>
-        public async Task<Group> GetGroupAsync(string id, CancellationToken cancellationToken = default)
+        /// <returns>A WorkOS Directory Group record.</returns>
+        public async Task<Group> GetGroup(string id, CancellationToken cancellationToken = default)
         {
             var request = new WorkOSRequest
             {
@@ -229,7 +146,7 @@
                 Path = $"/directory_groups/{id}",
             };
 
-            return await this.Client.MakeAPIRequestAsync<Group>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<Group>(request, cancellationToken);
         }
     }
 }

--- a/src/WorkOS.net/Services/Passwordless/PasswordlessService.cs
+++ b/src/WorkOS.net/Services/Passwordless/PasswordlessService.cs
@@ -30,28 +30,11 @@
         /// Creates a Passwordless Session for authenticating a user.
         /// </summary>
         /// <param name="options">Parameters to create the Passwordless Session.</param>
-        /// <returns>The created Passwordless Session.</returns>
-        public PasswordlessSession CreateSession(CreatePasswordlessSessionOptions options)
-        {
-            var request = new WorkOSRequest
-            {
-                Options = options,
-                Method = HttpMethod.Post,
-                Path = "/passwordless/sessions",
-            };
-
-            return this.Client.MakeAPIRequest<PasswordlessSession>(request);
-        }
-
-        /// <summary>
-        /// Asynchronously creates a Passwordless Session for authenticating a user.
-        /// </summary>
-        /// <param name="options">Parameters to create the Passwordless Session.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping the created Passwordless Session.</returns>
-        public async Task<PasswordlessSession> CreateSessionAsync(
+        /// <returns>The created Passwordless Session.</returns>
+        public async Task<PasswordlessSession> CreateSession(
             CreatePasswordlessSessionOptions options,
             CancellationToken cancellationToken = default)
         {
@@ -62,35 +45,18 @@
                 Path = "/passwordless/sessions",
             };
 
-            return await this.Client.MakeAPIRequestAsync<PasswordlessSession>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<PasswordlessSession>(request, cancellationToken);
         }
 
         /// <summary>
         /// Sends the link to confirm a Passwordless Session.
         /// </summary>
         /// <param name="id">Passwordless Session identifier.</param>
-        /// <returns>True if successful.</returns>
-        public bool SendSession(string id)
-        {
-            var request = new WorkOSRequest
-            {
-                Method = HttpMethod.Post,
-                Path = $"/passwordless/sessions/{id}/send",
-            };
-
-            this.Client.MakeAPIRequest<object>(request);
-            return true;
-        }
-
-        /// <summary>
-        /// Asynchronously sends the link to confirm a Passwordless Session.
-        /// </summary>
-        /// <param name="id">Passwordless Session identifier.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping True if successful.</returns>
-        public async Task<bool> SendSessionAsync(string id, CancellationToken cancellationToken = default)
+        /// <returns>True if successful.</returns>
+        public async Task<bool> SendSession(string id, CancellationToken cancellationToken = default)
         {
             var request = new WorkOSRequest
             {
@@ -98,7 +64,7 @@
                 Path = $"/passwordless/sessions/{id}/send",
             };
 
-            await this.Client.MakeAPIRequestAsync<object>(request, cancellationToken);
+            await this.Client.MakeAPIRequest<object>(request, cancellationToken);
             return true;
         }
     }

--- a/src/WorkOS.net/Services/Portal/PortalService.cs
+++ b/src/WorkOS.net/Services/Portal/PortalService.cs
@@ -30,28 +30,11 @@
         /// Fetches a list of Organizations.
         /// </summary>
         /// <param name="options">Filter options when searching for Organizations.</param>
-        /// <returns>A paginated list of Organizations.</returns>
-        public WorkOSList<Organization> ListOrganizations(ListOrganizationsOptions options = null)
-        {
-            var request = new WorkOSRequest
-            {
-                Options = options,
-                Method = HttpMethod.Get,
-                Path = "/organizations",
-            };
-
-            return this.Client.MakeAPIRequest<WorkOSList<Organization>>(request);
-        }
-
-        /// <summary>
-        /// Asynchronously fetches a list of Organizations.
-        /// </summary>
-        /// <param name="options">Filter options when searching for Organizations.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping a paginated list of Organizations.</returns>
-        public async Task<WorkOSList<Organization>> ListOrganizationsAsync(
+        /// <returns>A paginated list of Organizations.</returns>
+        public async Task<WorkOSList<Organization>> ListOrganizations(
             ListOrganizationsOptions options = null,
             CancellationToken cancellationToken = default)
         {
@@ -62,35 +45,18 @@
                 Path = "/organizations",
             };
 
-            return await this.Client.MakeAPIRequestAsync<WorkOSList<Organization>>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<WorkOSList<Organization>>(request, cancellationToken);
         }
 
         /// <summary>
         /// Creates an Organization.
         /// </summary>
         /// <param name="options">Parameters to create an Organization.</param>
-        /// <returns>The created Organization.</returns>
-        public Organization CreateOrganization(CreateOrganizationOptions options)
-        {
-            var request = new WorkOSRequest
-            {
-                Options = options,
-                Method = HttpMethod.Post,
-                Path = "/organizations",
-            };
-
-            return this.Client.MakeAPIRequest<Organization>(request);
-        }
-
-        /// <summary>
-        /// Asynchronously creates an Organization.
-        /// </summary>
-        /// <param name="options">Parameters to create an Organization.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping the created Organization.</returns>
-        public async Task<Organization> CreateOrganizationAsync(
+        /// <returns>The created Organization.</returns>
+        public async Task<Organization> CreateOrganization(
             CreateOrganizationOptions options,
             CancellationToken cancellationToken = default)
         {
@@ -101,35 +67,18 @@
                 Path = "/organizations",
             };
 
-            return await this.Client.MakeAPIRequestAsync<Organization>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<Organization>(request, cancellationToken);
         }
 
         /// <summary>
         /// Updates an Organization.
         /// </summary>
         /// <param name="options">Parameters to update an Organization.</param>
-        /// <returns>The updated Organization.</returns>
-        public Organization UpdateOrganization(UpdateOrganizationOptions options)
-        {
-            var request = new WorkOSRequest
-            {
-                Options = options,
-                Method = HttpMethod.Put,
-                Path = $"/organizations/{options.Organization}",
-            };
-
-            return this.Client.MakeAPIRequest<Organization>(request);
-        }
-
-        /// <summary>
-        /// Asynchronously updates an Organization.
-        /// </summary>
-        /// <param name="options">Parameters to update an Organization.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping the updated Organization.</returns>
-        public async Task<Organization> UpdateOrganizationAsync(
+        /// <returns>The updated Organization.</returns>
+        public async Task<Organization> UpdateOrganization(
           UpdateOrganizationOptions options,
           CancellationToken cancellationToken = default)
         {
@@ -140,36 +89,18 @@
                 Path = $"/organizations/{options.Organization}",
             };
 
-            return await this.Client.MakeAPIRequestAsync<Organization>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<Organization>(request, cancellationToken);
         }
 
         /// <summary>
         /// Generates a link to the Admin Portal.
         /// </summary>
         /// <param name="options">Parameters to create an Admin Portal link.</param>
-        /// <returns>The Admin Portal URL.</returns>
-        public string GenerateLink(GenerateLinkOptions options)
-        {
-            var request = new WorkOSRequest
-            {
-                Options = options,
-                Method = HttpMethod.Post,
-                Path = "/portal/generate_link",
-            };
-
-            var response = this.Client.MakeAPIRequest<GenerateLinkResponse>(request);
-            return response.Link;
-        }
-
-        /// <summary>
-        /// Asynchronously generates a link to the Admin Portal.
-        /// </summary>
-        /// <param name="options">Parameters to create an Admin Portal link.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping the Admin Portal URL.</returns>
-        public async Task<string> GenerateLinkAsync(
+        /// <returns>The Admin Portal URL.</returns>
+        public async Task<string> GenerateLink(
             GenerateLinkOptions options,
             CancellationToken cancellationToken = default)
         {
@@ -180,7 +111,7 @@
                 Path = "/portal/generate_link",
             };
 
-            var response = await this.Client.MakeAPIRequestAsync<GenerateLinkResponse>(request, cancellationToken);
+            var response = await this.Client.MakeAPIRequest<GenerateLinkResponse>(request, cancellationToken);
             return response.Link;
         }
     }

--- a/src/WorkOS.net/Services/SSO/SSOService.cs
+++ b/src/WorkOS.net/Services/SSO/SSOService.cs
@@ -47,30 +47,11 @@
         /// Retrieves a <see cref="Profile"/> for an authenticated User.
         /// </summary>
         /// <param name="options">Options to fetch an authenticated User.</param>
-        /// <returns>A WorkOS Profile record.</returns>
-        public GetProfileResponse GetProfile(GetProfileOptions options)
-        {
-            options.ClientSecret = this.Client.ApiKey;
-            var request = new WorkOSRequest
-            {
-                IsJsonContentType = false,
-                Options = options,
-                Method = HttpMethod.Post,
-                Path = "/sso/token",
-            };
-            return this.Client.MakeAPIRequest<GetProfileResponse>(request);
-        }
-
-        /// <summary>
-        /// Asynchronously retrieves a <see cref="Profile"/> for an
-        /// authenticated User.
-        /// </summary>
-        /// <param name="options">Options to fetch an authenticated User.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping a WorkOS Profile record.</returns>
-        public async Task<GetProfileResponse> GetProfileAsync(
+        /// <returns>A WorkOS Profile record.</returns>
+        public async Task<GetProfileResponse> GetProfile(
             GetProfileOptions options,
             CancellationToken cancellationToken = default)
         {
@@ -82,34 +63,18 @@
                 Method = HttpMethod.Post,
                 Path = "/sso/token",
             };
-            return await this.Client.MakeAPIRequestAsync<GetProfileResponse>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<GetProfileResponse>(request, cancellationToken);
         }
 
         /// <summary>
         /// Activates a WorkOS Draft Connection.
         /// </summary>
         /// <param name="options">Options to activate a Draft Connection.</param>
-        /// <returns>A WorkOS Connection.</returns>
-        public Connection CreateConnection(CreateConnectionOptions options)
-        {
-            var request = new WorkOSRequest
-            {
-                Options = options,
-                Method = HttpMethod.Post,
-                Path = "/connections",
-            };
-            return this.Client.MakeAPIRequest<Connection>(request);
-        }
-
-        /// <summary>
-        /// Asynchronously activates a WorkOS Draft Connection.
-        /// </summary>
-        /// <param name="options">Options to activate a Draft Connection.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping a WorkOS Connection record.</returns>
-        public async Task<Connection> CreateConnectionAsync(
+        /// <returns>A WorkOS Connection record.</returns>
+        public async Task<Connection> CreateConnection(
             CreateConnectionOptions options,
             CancellationToken cancellationToken = default)
         {
@@ -119,35 +84,18 @@
                 Method = HttpMethod.Post,
                 Path = "/connections",
             };
-            return await this.Client.MakeAPIRequestAsync<Connection>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<Connection>(request, cancellationToken);
         }
 
         /// <summary>
         /// Fetches a list of Connections.
         /// </summary>
         /// <param name="options">Filter options when searching for Connections.</param>
-        /// <returns>A paginated list of Connections.</returns>
-        public WorkOSList<Connection> ListConnections(ListConnectionsOptions options = null)
-        {
-            var request = new WorkOSRequest
-            {
-                Options = options,
-                Method = HttpMethod.Get,
-                Path = "/connections",
-            };
-
-            return this.Client.MakeAPIRequest<WorkOSList<Connection>>(request);
-        }
-
-        /// <summary>
-        /// Asynchronously fetches a list of Connections.
-        /// </summary>
-        /// <param name="options">Filter options when searching for Connections.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping a paginated list of Connections.</returns>
-        public async Task<WorkOSList<Connection>> ListConnectionsAsync(
+        /// <returns>A paginated list of Connections.</returns>
+        public async Task<WorkOSList<Connection>> ListConnections(
             ListConnectionsOptions options = null,
             CancellationToken cancellationToken = default)
         {
@@ -158,34 +106,18 @@
                 Path = "/connections",
             };
 
-            return await this.Client.MakeAPIRequestAsync<WorkOSList<Connection>>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<WorkOSList<Connection>>(request, cancellationToken);
         }
 
         /// <summary>
         /// Gets a Connection.
         /// </summary>
         /// <param name="id">Connection unique identifier.</param>
-        /// <returns>A WorkOS Connection record.</returns>
-        public Connection GetConnection(string id)
-        {
-            var request = new WorkOSRequest
-            {
-                Method = HttpMethod.Get,
-                Path = $"/connections/{id}",
-            };
-
-            return this.Client.MakeAPIRequest<Connection>(request);
-        }
-
-        /// <summary>
-        /// Asynchronously gets a Connection.
-        /// </summary>
-        /// <param name="id">Connection unique identifier.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping a WorkOS Connection record.</returns>
-        public async Task<Connection> GetConnectionAsync(string id, CancellationToken cancellationToken = default)
+        /// <returns>A WorkOS Connection record.</returns>
+        public async Task<Connection> GetConnection(string id, CancellationToken cancellationToken = default)
         {
             var request = new WorkOSRequest
             {
@@ -193,34 +125,18 @@
                 Path = $"/connections/{id}",
             };
 
-            return await this.Client.MakeAPIRequestAsync<Connection>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<Connection>(request, cancellationToken);
         }
 
         /// <summary>
         /// Deletes a Connection.
         /// </summary>
         /// <param name="id">Connection unique identifier.</param>
-        /// <returns>A deleted WorkOS Connection record.</returns>
-        public Connection DeleteConnection(string id)
-        {
-            var request = new WorkOSRequest
-            {
-                Method = HttpMethod.Delete,
-                Path = $"/connections/{id}",
-            };
-
-            return this.Client.MakeAPIRequest<Connection>(request);
-        }
-
-        /// <summary>
-        /// Asynchronously deletes a Connection.
-        /// </summary>
-        /// <param name="id">Connection unique identifier.</param>
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A Task wrapping a deleted WorkOS Connection record.</returns>
-        public async Task<Connection> DeleteConnectionAsync(string id, CancellationToken cancellationToken = default)
+        /// <returns>A deleted WorkOS Connection record.</returns>
+        public async Task<Connection> DeleteConnection(string id, CancellationToken cancellationToken = default)
         {
             var request = new WorkOSRequest
             {
@@ -228,7 +144,7 @@
                 Path = $"/connections/{id}",
             };
 
-            return await this.Client.MakeAPIRequestAsync<Connection>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<Connection>(request, cancellationToken);
         }
     }
 }

--- a/test/WorkOSTests/Services/AuditTrail/AuditTrailSeviceTest.cs
+++ b/test/WorkOSTests/Services/AuditTrail/AuditTrailSeviceTest.cs
@@ -82,7 +82,7 @@
         }
 
         [Fact]
-        public void TestCreateEvent()
+        public async void TestCreateEvent()
         {
             var mockResponse = new Dictionary<string, bool>
             {
@@ -95,32 +95,13 @@
                 HttpStatusCode.Created,
                 RequestUtilities.ToJsonString(mockResponse));
 
-            var success = this.service.CreateEvent(this.createEventOptions);
+            var success = await this.service.CreateEvent(this.createEventOptions);
             this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/events");
             Assert.True(success);
         }
 
         [Fact]
-        public async void TestCreateEventAsync()
-        {
-            var mockResponse = new Dictionary<string, bool>
-            {
-                { "success", true },
-            };
-
-            this.httpMock.MockResponse(
-                HttpMethod.Post,
-                "/events",
-                HttpStatusCode.Created,
-                RequestUtilities.ToJsonString(mockResponse));
-
-            var success = await this.service.CreateEventAsync(this.createEventOptions);
-            this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/events");
-            Assert.True(success);
-        }
-
-        [Fact]
-        public void TestListEvents()
+        public async void TestListEvents()
         {
             this.httpMock.MockResponse(
                 HttpMethod.Get,
@@ -128,24 +109,7 @@
                 HttpStatusCode.OK,
                 RequestUtilities.ToJsonString(this.mockListEventsResponse));
 
-            var response = this.service.ListEvents(this.listEventsOptions);
-
-            this.httpMock.AssertRequestWasMade(HttpMethod.Get, "/events");
-            Assert.Equal(
-                JsonConvert.SerializeObject(this.mockListEventsResponse),
-                JsonConvert.SerializeObject(response));
-        }
-
-        [Fact]
-        public async void TestListEventsAsync()
-        {
-            this.httpMock.MockResponse(
-                HttpMethod.Get,
-                "/events",
-                HttpStatusCode.OK,
-                RequestUtilities.ToJsonString(this.mockListEventsResponse));
-
-            var response = await this.service.ListEventsAsync(this.listEventsOptions);
+            var response = await this.service.ListEvents(this.listEventsOptions);
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Get, "/events");
             Assert.Equal(

--- a/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
+++ b/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
@@ -88,7 +88,7 @@
         }
 
         [Fact]
-        public void TestListDirectories()
+        public async void TestListDirectories()
         {
             var mockResponse = new WorkOSList<Directory>
             {
@@ -103,31 +103,7 @@
                 HttpStatusCode.OK,
                 RequestUtilities.ToJsonString(mockResponse));
 
-            var response = this.service.ListDirectories(this.listDirectoriesOptions);
-
-            this.httpMock.AssertRequestWasMade(HttpMethod.Get, "/directories");
-            Assert.Equal(
-                JsonConvert.SerializeObject(mockResponse),
-                JsonConvert.SerializeObject(response));
-        }
-
-        [Fact]
-        public async void TestListDirectoriesAsync()
-        {
-            var mockResponse = new WorkOSList<Directory>
-            {
-                Data = new List<Directory>
-                {
-                    this.mockDirectory,
-                },
-            };
-            this.httpMock.MockResponse(
-                HttpMethod.Get,
-                "/directories",
-                HttpStatusCode.OK,
-                RequestUtilities.ToJsonString(mockResponse));
-
-            var response = await this.service.ListDirectoriesAsync(this.listDirectoriesOptions);
+            var response = await this.service.ListDirectories(this.listDirectoriesOptions);
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Get, "/directories");
             Assert.Equal(
@@ -152,7 +128,7 @@
         }
 
         [Fact]
-        public void TestListUsers()
+        public async void TestListUsers()
         {
             var mockResponse = new WorkOSList<User>
             {
@@ -167,7 +143,7 @@
                 HttpStatusCode.OK,
                 RequestUtilities.ToJsonString(mockResponse));
 
-            var response = this.service.ListUsers(this.listUsersOptions);
+            var response = await this.service.ListUsers(this.listUsersOptions);
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Get, "/directory_users");
             Assert.Equal(
@@ -176,31 +152,7 @@
         }
 
         [Fact]
-        public async void TestListUsersAsync()
-        {
-            var mockResponse = new WorkOSList<User>
-            {
-                Data = new List<User>
-                {
-                    this.mockUser,
-                },
-            };
-            this.httpMock.MockResponse(
-                HttpMethod.Get,
-                "/directory_users",
-                HttpStatusCode.OK,
-                RequestUtilities.ToJsonString(mockResponse));
-
-            var response = await this.service.ListUsersAsync(this.listUsersOptions);
-
-            this.httpMock.AssertRequestWasMade(HttpMethod.Get, "/directory_users");
-            Assert.Equal(
-                JsonConvert.SerializeObject(mockResponse),
-                JsonConvert.SerializeObject(response));
-        }
-
-        [Fact]
-        public void TestGetUser()
+        public async void TestGetUser()
         {
             this.httpMock.MockResponse(
                 HttpMethod.Get,
@@ -208,7 +160,7 @@
                 HttpStatusCode.OK,
                 RequestUtilities.ToJsonString(this.mockUser));
 
-            var response = this.service.GetUser(this.mockUser.Id);
+            var response = await this.service.GetUser(this.mockUser.Id);
 
             this.httpMock.AssertRequestWasMade(
                 HttpMethod.Get,
@@ -219,26 +171,7 @@
         }
 
         [Fact]
-        public async void TestGetUserAsync()
-        {
-            this.httpMock.MockResponse(
-                HttpMethod.Get,
-                $"/directory_users/{this.mockUser.Id}",
-                HttpStatusCode.OK,
-                RequestUtilities.ToJsonString(this.mockUser));
-
-            var response = await this.service.GetUserAsync(this.mockUser.Id);
-
-            this.httpMock.AssertRequestWasMade(
-                HttpMethod.Get,
-                $"/directory_users/{this.mockUser.Id}");
-            Assert.Equal(
-                JsonConvert.SerializeObject(this.mockUser),
-                JsonConvert.SerializeObject(response));
-        }
-
-        [Fact]
-        public void TestListGroups()
+        public async void TestListGroups()
         {
             var mockResponse = new WorkOSList<Group>
             {
@@ -253,7 +186,7 @@
                 HttpStatusCode.OK,
                 RequestUtilities.ToJsonString(mockResponse));
 
-            var response = this.service.ListGroups(this.listGroupsOptions);
+            var response = await this.service.ListGroups(this.listGroupsOptions);
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Get, "/directory_groups");
             Assert.Equal(
@@ -262,31 +195,7 @@
         }
 
         [Fact]
-        public async void TestListGroupsAsync()
-        {
-            var mockResponse = new WorkOSList<Group>
-            {
-                Data = new List<Group>
-                {
-                    this.mockGroup,
-                },
-            };
-            this.httpMock.MockResponse(
-                HttpMethod.Get,
-                "/directory_groups",
-                HttpStatusCode.OK,
-                RequestUtilities.ToJsonString(mockResponse));
-
-            var response = await this.service.ListGroupsAsync(this.listGroupsOptions);
-
-            this.httpMock.AssertRequestWasMade(HttpMethod.Get, "/directory_groups");
-            Assert.Equal(
-                JsonConvert.SerializeObject(mockResponse),
-                JsonConvert.SerializeObject(response));
-        }
-
-        [Fact]
-        public void TestGetGroup()
+        public async void TestGetGroup()
         {
             this.httpMock.MockResponse(
                 HttpMethod.Get,
@@ -294,26 +203,7 @@
                 HttpStatusCode.OK,
                 RequestUtilities.ToJsonString(this.mockGroup));
 
-            var response = this.service.GetGroup(this.mockGroup.Id);
-
-            this.httpMock.AssertRequestWasMade(
-                HttpMethod.Get,
-                $"/directory_groups/{this.mockGroup.Id}");
-            Assert.Equal(
-                JsonConvert.SerializeObject(this.mockGroup),
-                JsonConvert.SerializeObject(response));
-        }
-
-        [Fact]
-        public async void TestGetGroupAsync()
-        {
-            this.httpMock.MockResponse(
-                HttpMethod.Get,
-                $"/directory_groups/{this.mockGroup.Id}",
-                HttpStatusCode.OK,
-                RequestUtilities.ToJsonString(this.mockGroup));
-
-            var response = await this.service.GetGroupAsync(this.mockGroup.Id);
+            var response = await this.service.GetGroup(this.mockGroup.Id);
 
             this.httpMock.AssertRequestWasMade(
                 HttpMethod.Get,

--- a/test/WorkOSTests/Services/Passwordless/PasswordlessServiceTest.cs
+++ b/test/WorkOSTests/Services/Passwordless/PasswordlessServiceTest.cs
@@ -46,14 +46,14 @@
         }
 
         [Fact]
-        public void TestCreateSession()
+        public async void TestCreateSession()
         {
             this.httpMock.MockResponse(
                 HttpMethod.Post,
                 "/passwordless/sessions",
                 HttpStatusCode.Created,
                 RequestUtilities.ToJsonString(this.mockPasswordlessSession));
-            var response = this.service.CreateSession(this.createPasswordlessSessionOptions);
+            var response = await this.service.CreateSession(this.createPasswordlessSessionOptions);
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/passwordless/sessions");
             Assert.Equal(
@@ -62,23 +62,7 @@
         }
 
         [Fact]
-        public async void TestCreateSessionAsync()
-        {
-            this.httpMock.MockResponse(
-                HttpMethod.Post,
-                "/passwordless/sessions",
-                HttpStatusCode.Created,
-                RequestUtilities.ToJsonString(this.mockPasswordlessSession));
-            var response = await this.service.CreateSessionAsync(this.createPasswordlessSessionOptions);
-
-            this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/passwordless/sessions");
-            Assert.Equal(
-                JsonConvert.SerializeObject(this.mockPasswordlessSession),
-                JsonConvert.SerializeObject(response));
-        }
-
-        [Fact]
-        public void TestSendSession()
+        public async void TestSendSession()
         {
             var id = this.mockPasswordlessSession.Id;
 
@@ -91,29 +75,7 @@
                 $"/passwordless/sessions/{id}/send",
                 HttpStatusCode.Created,
                 RequestUtilities.ToJsonString(mockResponse));
-            var success = this.service.SendSession(id);
-
-            this.httpMock.AssertRequestWasMade(
-                HttpMethod.Post,
-                $"/passwordless/sessions/{id}/send");
-            Assert.True(success);
-        }
-
-        [Fact]
-        public async void TestSendSessionAsync()
-        {
-            var id = this.mockPasswordlessSession.Id;
-
-            var mockResponse = new Dictionary<string, bool>
-            {
-                { "success", true },
-            };
-            this.httpMock.MockResponse(
-                HttpMethod.Post,
-                $"/passwordless/sessions/{id}/send",
-                HttpStatusCode.Created,
-                RequestUtilities.ToJsonString(mockResponse));
-            var success = await this.service.SendSessionAsync(id);
+            var success = await this.service.SendSession(id);
 
             this.httpMock.AssertRequestWasMade(
                 HttpMethod.Post,

--- a/test/WorkOSTests/Services/Portal/PortalServiceTest.cs
+++ b/test/WorkOSTests/Services/Portal/PortalServiceTest.cs
@@ -101,7 +101,7 @@
         }
 
         [Fact]
-        public void TestListOrganizations()
+        public async void TestListOrganizations()
         {
             var mockResponse = new WorkOSList<Organization>
             {
@@ -115,7 +115,7 @@
                 "/organizations",
                 HttpStatusCode.OK,
                 RequestUtilities.ToJsonString(mockResponse));
-            var response = this.service.ListOrganizations(this.listOrganizationsOptions);
+            var response = await this.service.ListOrganizations(this.listOrganizationsOptions);
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Get, "/organizations");
             Assert.Equal(
@@ -124,37 +124,14 @@
         }
 
         [Fact]
-        public async void TestListOrganizationsAsync()
-        {
-            var mockResponse = new WorkOSList<Organization>
-            {
-                Data = new List<Organization>
-                {
-                    this.mockOrganization,
-                },
-            };
-            this.httpMock.MockResponse(
-                HttpMethod.Get,
-                "/organizations",
-                HttpStatusCode.OK,
-                RequestUtilities.ToJsonString(mockResponse));
-            var response = await this.service.ListOrganizationsAsync(this.listOrganizationsOptions);
-
-            this.httpMock.AssertRequestWasMade(HttpMethod.Get, "/organizations");
-            Assert.Equal(
-                JsonConvert.SerializeObject(mockResponse),
-                JsonConvert.SerializeObject(response));
-        }
-
-        [Fact]
-        public void TestCreateOrganization()
+        public async void TestCreateOrganization()
         {
             this.httpMock.MockResponse(
                 HttpMethod.Post,
                 "/organizations",
                 HttpStatusCode.Created,
                 RequestUtilities.ToJsonString(this.mockOrganization));
-            var response = this.service.CreateOrganization(this.createOrganizationOptions);
+            var response = await this.service.CreateOrganization(this.createOrganizationOptions);
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/organizations");
             Assert.Equal(
@@ -163,30 +140,14 @@
         }
 
         [Fact]
-        public async void TestCreateOrganizationAsync()
-        {
-            this.httpMock.MockResponse(
-                HttpMethod.Post,
-                "/organizations",
-                HttpStatusCode.Created,
-                RequestUtilities.ToJsonString(this.mockOrganization));
-            var response = await this.service.CreateOrganizationAsync(this.createOrganizationOptions);
-
-            this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/organizations");
-            Assert.Equal(
-                JsonConvert.SerializeObject(this.mockOrganization),
-                JsonConvert.SerializeObject(response));
-        }
-
-        [Fact]
-        public void TestUpdateOrganization()
+        public async void TestUpdateOrganization()
         {
             this.httpMock.MockResponse(
                 HttpMethod.Put,
                 $"/organizations/{this.updateOrganizationOptions.Organization}",
                 HttpStatusCode.OK,
                 RequestUtilities.ToJsonString(this.mockOrganization));
-            var response = this.service.UpdateOrganization(this.updateOrganizationOptions);
+            var response = await this.service.UpdateOrganization(this.updateOrganizationOptions);
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Put, $"/organizations/{this.updateOrganizationOptions.Organization}");
             Assert.Equal(
@@ -195,72 +156,28 @@
         }
 
         [Fact]
-        public async void TestUpdateOrganizationAsync()
-        {
-            this.httpMock.MockResponse(
-                HttpMethod.Put,
-                $"/organizations/{this.updateOrganizationOptions.Organization}",
-                HttpStatusCode.OK,
-                RequestUtilities.ToJsonString(this.mockOrganization));
-            var response = await this.service.UpdateOrganizationAsync(this.updateOrganizationOptions);
-
-            this.httpMock.AssertRequestWasMade(HttpMethod.Put, $"/organizations/{this.updateOrganizationOptions.Organization}");
-            Assert.Equal(
-                JsonConvert.SerializeObject(this.mockOrganization),
-                JsonConvert.SerializeObject(response));
-        }
-
-        [Fact]
-        public void TestGenerateLinkSSO()
+        public async void TestGenerateLinkSSO()
         {
             this.httpMock.MockResponse(
                 HttpMethod.Post,
                 "/portal/generate_link",
                 HttpStatusCode.Created,
                 RequestUtilities.ToJsonString(this.mockGenerateLinkResponse));
-            var link = this.service.GenerateLink(this.generateLinkOptionsSSO);
+            var link = await this.service.GenerateLink(this.generateLinkOptionsSSO);
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/portal/generate_link");
             Assert.Equal(this.mockGenerateLinkResponse.Link, link);
         }
 
         [Fact]
-        public void TestGenerateLinkDSync()
+        public async void TestGenerateLinkDSync()
         {
             this.httpMock.MockResponse(
                 HttpMethod.Post,
                 "/portal/generate_link",
                 HttpStatusCode.Created,
                 RequestUtilities.ToJsonString(this.mockGenerateLinkResponse));
-            var link = this.service.GenerateLink(this.generateLinkOptionsDSync);
-
-            this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/portal/generate_link");
-            Assert.Equal(this.mockGenerateLinkResponse.Link, link);
-        }
-
-        [Fact]
-        public async void TestGenerateLinkAsyncSSO()
-        {
-            this.httpMock.MockResponse(
-                HttpMethod.Post,
-                "/portal/generate_link",
-                HttpStatusCode.Created,
-                RequestUtilities.ToJsonString(this.mockGenerateLinkResponse));
-            var link = await this.service.GenerateLinkAsync(this.generateLinkOptionsSSO);
-
-            this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/portal/generate_link");
-            Assert.Equal(this.mockGenerateLinkResponse.Link, link);
-        }
-
-        [Fact]
-        public async void TestGenerateLinkAsyncDSync()
-        {
-            this.httpMock.MockResponse(
-                HttpMethod.Post,
-                "/portal/generate_link",
-                HttpStatusCode.Created,
-                RequestUtilities.ToJsonString(this.mockGenerateLinkResponse));
-            var link = await this.service.GenerateLinkAsync(this.generateLinkOptionsDSync);
+            var link = await this.service.GenerateLink(this.generateLinkOptionsDSync);
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/portal/generate_link");
             Assert.Equal(this.mockGenerateLinkResponse.Link, link);

--- a/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
+++ b/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
@@ -131,7 +131,7 @@
         }
 
         [Fact]
-        public void TestGetProfile()
+        public async void TestGetProfile()
         {
             var mockProfile = new Profile
             {
@@ -167,7 +167,7 @@
                 ClientId = "client_123",
                 Code = "code",
             };
-            var response = this.service.GetProfile(options);
+            var response = await this.service.GetProfile(options);
             var profile = response.Profile;
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/sso/token");
@@ -178,54 +178,7 @@
         }
 
         [Fact]
-        public async void TestGetProfileAsync()
-        {
-            var mockProfile = new Profile
-            {
-                Id = "profile_0",
-                IdpId = "123",
-                ConnectionId = "conn_123",
-                ConnectionType = ConnectionType.OktaSAML,
-                Email = "rick@sanchez.com",
-                FirstName = "Rick",
-                LastName = "Sanchez",
-                RawAttributes = new Dictionary<string, object>()
-                {
-                    { "idp_id", "123" },
-                    { "email", "rick@sanchez.com" },
-                    { "first_name", "Rick" },
-                    { "last_name", "Sanchez" },
-                },
-            };
-            var profileResponse = new GetProfileResponse
-            {
-                AccessToken = "token",
-                Profile = mockProfile,
-            };
-
-            this.httpMock.MockResponse(
-                HttpMethod.Post,
-                "/sso/token",
-                HttpStatusCode.Created,
-                RequestUtilities.ToJsonString(profileResponse));
-
-            var options = new GetProfileOptions
-            {
-                ClientId = "client_123",
-                Code = "code",
-            };
-            var response = await this.service.GetProfileAsync(options);
-            var profile = response.Profile;
-
-            this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/sso/token");
-            Assert.NotNull(profile);
-            Assert.Equal(
-                JsonConvert.SerializeObject(mockProfile),
-                JsonConvert.SerializeObject(profile));
-        }
-
-        [Fact]
-        public void TestCreateConnection()
+        public async void TestCreateConnection()
         {
             var mockConnection = new Connection
             {
@@ -245,7 +198,7 @@
             {
                 Source = "source",
             };
-            var connection = this.service.CreateConnection(options);
+            var connection = await this.service.CreateConnection(options);
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/connections");
             Assert.NotNull(connection);
@@ -255,37 +208,7 @@
         }
 
         [Fact]
-        public async void TestCreateConnectionAsync()
-        {
-            var mockConnection = new Connection
-            {
-                Id = "connection_id",
-                Name = "Terrace House",
-                State = ConnectionState.Active,
-                ConnectionType = ConnectionType.OktaSAML,
-            };
-
-            this.httpMock.MockResponse(
-                HttpMethod.Post,
-                "/connections",
-                HttpStatusCode.Created,
-                RequestUtilities.ToJsonString(mockConnection));
-
-            var options = new CreateConnectionOptions
-            {
-                Source = "source",
-            };
-            var connection = await this.service.CreateConnectionAsync(options);
-
-            this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/connections");
-            Assert.NotNull(connection);
-            Assert.Equal(
-                JsonConvert.SerializeObject(mockConnection),
-                JsonConvert.SerializeObject(connection));
-        }
-
-        [Fact]
-        public void TestListConnections()
+        public async void TestListConnections()
         {
             var mockResponse = new WorkOSList<Connection>
             {
@@ -300,7 +223,7 @@
                 HttpStatusCode.OK,
                 RequestUtilities.ToJsonString(mockResponse));
 
-            var response = this.service.ListConnections(this.listConnectionsOptions);
+            var response = await this.service.ListConnections(this.listConnectionsOptions);
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Get, "/connections");
             Assert.Equal(
@@ -309,31 +232,7 @@
         }
 
         [Fact]
-        public async void TestListConnectionsAsync()
-        {
-            var mockResponse = new WorkOSList<Connection>
-            {
-                Data = new List<Connection>
-                {
-                    this.mockConnection,
-                },
-            };
-            this.httpMock.MockResponse(
-                HttpMethod.Get,
-                "/connections",
-                HttpStatusCode.OK,
-                RequestUtilities.ToJsonString(mockResponse));
-
-            var response = await this.service.ListConnectionsAsync(this.listConnectionsOptions);
-
-            this.httpMock.AssertRequestWasMade(HttpMethod.Get, "/connections");
-            Assert.Equal(
-                JsonConvert.SerializeObject(mockResponse),
-                JsonConvert.SerializeObject(response));
-        }
-
-        [Fact]
-        public void TestGetConnection()
+        public async void TestGetConnection()
         {
             this.httpMock.MockResponse(
                 HttpMethod.Get,
@@ -341,26 +240,7 @@
                 HttpStatusCode.OK,
                 RequestUtilities.ToJsonString(this.mockConnection));
 
-            var response = this.service.GetConnection(this.mockConnection.Id);
-
-            this.httpMock.AssertRequestWasMade(
-                HttpMethod.Get,
-                $"/connections/{this.mockConnection.Id}");
-            Assert.Equal(
-                JsonConvert.SerializeObject(this.mockConnection),
-                JsonConvert.SerializeObject(response));
-        }
-
-        [Fact]
-        public async void TestGetConnectionAsync()
-        {
-            this.httpMock.MockResponse(
-                HttpMethod.Get,
-                $"/connections/{this.mockConnection.Id}",
-                HttpStatusCode.OK,
-                RequestUtilities.ToJsonString(this.mockConnection));
-
-            var response = await this.service.GetConnectionAsync(this.mockConnection.Id);
+            var response = await this.service.GetConnection(this.mockConnection.Id);
 
             this.httpMock.AssertRequestWasMade(
                 HttpMethod.Get,


### PR DESCRIPTION
This PR removes all synchronous methods and drops the `Async` suffix from the async methods.

### Motivation

The synchronous methods are a footgun, as calling them results in the thread being blocked until the API request completes. As such, we should not provide them.

With the removal of the sync/async variants, the `Async` suffix is now redundant, hence its removal.

This is a breaking change that will be part of `v1.0.0`.

Resolves SDK-33.