### PR TITLE
Rename `GetProfile` to `GetProfileAndToken`

### DIFF
--- a/src/WorkOS.net/Services/SSO/SSOService.cs
+++ b/src/WorkOS.net/Services/SSO/SSOService.cs
@@ -51,8 +51,8 @@
         /// An optional token to cancel the request.
         /// </param>
         /// <returns>A WorkOS Profile record.</returns>
-        public async Task<GetProfileResponse> GetProfile(
-            GetProfileOptions options,
+        public async Task<GetProfileAndTokenResponse> GetProfileAndToken(
+            GetProfileAndTokenOptions options,
             CancellationToken cancellationToken = default)
         {
             options.ClientSecret = this.Client.ApiKey;
@@ -63,7 +63,7 @@
                 Method = HttpMethod.Post,
                 Path = "/sso/token",
             };
-            return await this.Client.MakeAPIRequest<GetProfileResponse>(request, cancellationToken);
+            return await this.Client.MakeAPIRequest<GetProfileAndTokenResponse>(request, cancellationToken);
         }
 
         /// <summary>

--- a/src/WorkOS.net/Services/SSO/_interfaces/GetProfileAndTokenOptions.cs
+++ b/src/WorkOS.net/Services/SSO/_interfaces/GetProfileAndTokenOptions.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// Describes the options to get a Profile.
     /// </summary>
-    public class GetProfileOptions : BaseOptions
+    public class GetProfileAndTokenOptions : BaseOptions
     {
         /// <summary>
         /// Specifies the grant type. Will always be `authorization_code`.

--- a/src/WorkOS.net/Services/SSO/_interfaces/GetProfileAndTokenResponse.cs
+++ b/src/WorkOS.net/Services/SSO/_interfaces/GetProfileAndTokenResponse.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// The response from the WorkOS API when fetching a Profile.
     /// </summary>
-    public class GetProfileResponse
+    public class GetProfileAndTokenResponse
     {
         /// <summary>
         /// An access token for the Profile.

--- a/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
+++ b/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
@@ -131,7 +131,7 @@
         }
 
         [Fact]
-        public async void TestGetProfile()
+        public async void TestGetProfileAndToken()
         {
             var mockProfile = new Profile
             {
@@ -150,7 +150,7 @@
                     { "last_name", "Sanchez" },
                 },
             };
-            var profileResponse = new GetProfileResponse
+            var profileAndTokenResponse = new GetProfileAndTokenResponse
             {
                 AccessToken = "token",
                 Profile = mockProfile,
@@ -160,14 +160,14 @@
                 HttpMethod.Post,
                 "/sso/token",
                 HttpStatusCode.Created,
-                RequestUtilities.ToJsonString(profileResponse));
+                RequestUtilities.ToJsonString(profileAndTokenResponse));
 
-            var options = new GetProfileOptions
+            var options = new GetProfileAndTokenOptions
             {
                 ClientId = "client_123",
                 Code = "code",
             };
-            var response = await this.service.GetProfile(options);
+            var response = await this.service.GetProfileAndToken(options);
             var profile = response.Profile;
 
             this.httpMock.AssertRequestWasMade(HttpMethod.Post, "/sso/token");


### PR DESCRIPTION
This PR renames the `GetProfile` method to `GetProfileAndToken`.

This is a breaking change that will be part of `v1.0.0`.

Resolves SDK-159.