### PR TITLE
Add `GetProfile` method

### DIFF
--- a/src/WorkOS.net/Client/WorkOSClient.cs
+++ b/src/WorkOS.net/Client/WorkOSClient.cs
@@ -107,7 +107,15 @@
             var userAgentString = $"workos-dotnet/{SdkVersion}";
             var requestMessage = new HttpRequestMessage(request.Method, uri);
             requestMessage.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("utf-8"));
-            requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", this.ApiKey);
+
+            if (!string.IsNullOrWhiteSpace(request.AccessToken))
+            {
+                requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", request.AccessToken);
+            }
+            else
+            {
+                requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", this.ApiKey);
+            }
 
             requestMessage.Headers.TryAddWithoutValidation("User-Agent", userAgentString);
             if (request.WorkOSHeaders != null)

--- a/src/WorkOS.net/Client/_interfaces/WorkOSRequest.cs
+++ b/src/WorkOS.net/Client/_interfaces/WorkOSRequest.cs
@@ -25,6 +25,11 @@
         public string Path { get; set; }
 
         /// <summary>
+        /// The access token to use for authentication instead of an API key.
+        /// </summary>
+        public string AccessToken { get; set; }
+
+        /// <summary>
         /// Dictionary of custom WorkOS headers.
         /// </summary>
         public IDictionary<string, string> WorkOSHeaders { get; set; }

--- a/src/WorkOS.net/Services/SSO/SSOService.cs
+++ b/src/WorkOS.net/Services/SSO/SSOService.cs
@@ -67,6 +67,27 @@
         }
 
         /// <summary>
+        /// Retrieves a <see cref="Profile"/> for an authenticated User using an access token.
+        /// </summary>
+        /// <param name="options">Options to fetch an authenticated User.</param>
+        /// <param name="cancellationToken">
+        /// An optional token to cancel the request.
+        /// </param>
+        /// <returns>A WorkOS Profile record.</returns>
+        public async Task<Profile> GetProfile(
+            GetProfileOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            var request = new WorkOSRequest
+            {
+                AccessToken = options.AccessToken,
+                Method = HttpMethod.Get,
+                Path = "/sso/profile",
+            };
+            return await this.Client.MakeAPIRequest<Profile>(request, cancellationToken);
+        }
+
+        /// <summary>
         /// Fetches a list of Connections.
         /// </summary>
         /// <param name="options">Filter options when searching for Connections.</param>

--- a/src/WorkOS.net/Services/SSO/_interfaces/GetProfileOptions.cs
+++ b/src/WorkOS.net/Services/SSO/_interfaces/GetProfileOptions.cs
@@ -1,0 +1,13 @@
+namespace WorkOS
+{
+    /// <summary>
+    /// Describes the options to get a Profile.
+    /// </summary>
+    public class GetProfileOptions
+    {
+        /// <summary>
+        /// The access token to use to retrieve the Profile.
+        /// </summary>
+        public string AccessToken { get; set; }
+    }
+}

--- a/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
+++ b/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
@@ -178,6 +178,44 @@
         }
 
         [Fact]
+        public async void TestGetProfile()
+        {
+            var mockProfile = new Profile
+            {
+                Id = "profile_0",
+                IdpId = "123",
+                ConnectionId = "conn_123",
+                ConnectionType = ConnectionType.OktaSAML,
+                Email = "rick@sanchez.com",
+                FirstName = "Rick",
+                LastName = "Sanchez",
+                RawAttributes = new Dictionary<string, object>()
+                {
+                    { "idp_id", "123" },
+                    { "email", "rick@sanchez.com" },
+                    { "first_name", "Rick" },
+                    { "last_name", "Sanchez" },
+                },
+            };
+
+            this.httpMock.MockResponseWithAuthorizationHeader(
+                HttpMethod.Get,
+                "/sso/profile",
+                HttpStatusCode.OK,
+                RequestUtilities.ToJsonString(mockProfile),
+                "access_token");
+
+            var options = new GetProfileOptions
+            {
+                AccessToken = "access_token",
+            };
+            var profile = await this.service.GetProfile(options);
+
+            this.httpMock.AssertRequestWasMade(HttpMethod.Get, "/sso/profile");
+            this.httpMock.AssertAuthorizationBearerHeader("access_token");
+        }
+
+        [Fact]
         public async void TestListConnections()
         {
             var mockResponse = new WorkOSList<Connection>

--- a/test/WorkOSTests/Utilities/HttpMock.cs
+++ b/test/WorkOSTests/Utilities/HttpMock.cs
@@ -34,6 +34,19 @@
                     ItExpr.IsAny<CancellationToken>());
         }
 
+        public void AssertAuthorizationBearerHeader(string value)
+        {
+            this.MockHandler.Protected()
+                .Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Headers.Authorization != null &&
+                        m.Headers.Authorization.Scheme == "Bearer" &&
+                        m.Headers.Authorization.Parameter == value),
+                    ItExpr.IsAny<CancellationToken>());
+        }
+
         public void MockResponse(
             HttpMethod method,
             string path,
@@ -52,6 +65,31 @@
                     ItExpr.Is<HttpRequestMessage>(m =>
                         m.Method == method &&
                         m.RequestUri.AbsolutePath == path),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(responseMessage);
+        }
+
+        public void MockResponseWithAuthorizationHeader(
+            HttpMethod method,
+            string path,
+            HttpStatusCode status,
+            string response,
+            string bearerToken)
+        {
+            var responseMessage = new HttpResponseMessage
+            {
+                Content = new StringContent(response),
+                StatusCode = status,
+            };
+
+            this.MockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == method &&
+                        m.RequestUri.AbsolutePath == path &&
+                        m.Headers.Authorization.Scheme == "Bearer" &&
+                        m.Headers.Authorization.Parameter == bearerToken),
                     ItExpr.IsAny<CancellationToken>())
                 .ReturnsAsync(responseMessage);
         }


### PR DESCRIPTION
This PR adds a `GetProfile` method for calling the `/sso/profile` endpoint.

Resolves SDK-194.