### PR TITLE
Fix `DeleteOrganization` implementation

### DIFF
--- a/src/WorkOS.net/Client/WorkOSClient.cs
+++ b/src/WorkOS.net/Client/WorkOSClient.cs
@@ -97,7 +97,7 @@
             WorkOSRequest request,
             CancellationToken cancellationToken = default)
         {
-            var response = await this.MakeRawAPIRequest(request).ConfigureAwait(false);
+            var response = await this.MakeRawAPIRequest(request, cancellationToken).ConfigureAwait(false);
 
             var reader = new StreamReader(
                 await response.Content.ReadAsStreamAsync().ConfigureAwait(false));

--- a/src/WorkOS.net/Client/WorkOSClient.cs
+++ b/src/WorkOS.net/Client/WorkOSClient.cs
@@ -71,6 +71,12 @@
             };
         }
 
+        /// <summary>
+        /// Makes a request to the WorkOS API.
+        /// </summary>
+        /// <param name="request">The request to make to the WorkOS API.</param>
+        /// <param name="cancellationToken">A token used to cancel the request.</param>
+        /// <returns>The response from the WorkOS API.</returns>
         public async Task<HttpResponseMessage> MakeRawAPIRequest(
             WorkOSRequest request,
             CancellationToken cancellationToken = default)
@@ -81,7 +87,7 @@
         }
 
         /// <summary>
-        /// Makes a request to the WorkOS API.
+        /// Makes a request to the WorkOS API and parses the JSON response.
         /// </summary>
         /// <typeparam name="T">The return type from the request.</typeparam>
         /// <param name="request">The request to make to the WorkOS API.</param>

--- a/src/WorkOS.net/Client/WorkOSClient.cs
+++ b/src/WorkOS.net/Client/WorkOSClient.cs
@@ -71,6 +71,15 @@
             };
         }
 
+        public async Task<HttpResponseMessage> MakeRawAPIRequest(
+            WorkOSRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var requestMessage = this.CreateHttpRequestMessage(request);
+
+            return await this.HttpClient.SendAsync(requestMessage, cancellationToken);
+        }
+
         /// <summary>
         /// Makes a request to the WorkOS API.
         /// </summary>
@@ -82,11 +91,7 @@
             WorkOSRequest request,
             CancellationToken cancellationToken = default)
         {
-            var requestMessage = this.CreateHttpRequestMessage(request);
-
-            HttpResponseMessage response = await this.HttpClient
-                    .SendAsync(requestMessage, cancellationToken)
-                    .ConfigureAwait(false);
+            var response = await this.MakeRawAPIRequest(request).ConfigureAwait(false);
 
             var reader = new StreamReader(
                 await response.Content.ReadAsStreamAsync().ConfigureAwait(false));

--- a/src/WorkOS.net/Services/Organizations/OrganizationsService.cs
+++ b/src/WorkOS.net/Services/Organizations/OrganizationsService.cs
@@ -96,8 +96,8 @@ namespace WorkOS
         /// <param name="cancellationToken">
         /// An optional token to cancel the request.
         /// </param>
-        /// <returns>A deleted WorkOS Organization record.</returns>
-        public async Task<Organization> DeleteOrganization(string id, CancellationToken cancellationToken = default)
+        /// <returns>A Task.</returns>
+        public async Task DeleteOrganization(string id, CancellationToken cancellationToken = default)
         {
             var request = new WorkOSRequest
             {
@@ -105,7 +105,7 @@ namespace WorkOS
                 Path = $"/organizations/{id}",
             };
 
-            return await this.Client.MakeAPIRequest<Organization>(request, cancellationToken);
+            await this.Client.MakeRawAPIRequest(request, cancellationToken);
         }
 
         /// <summary>

--- a/test/WorkOSTests/Services/Organizations/OrganizationsServiceTest.cs
+++ b/test/WorkOSTests/Services/Organizations/OrganizationsServiceTest.cs
@@ -134,15 +134,15 @@ namespace WorkOSTests
         }
 
         [Fact]
-        public void TestDeleteOrganization()
+        public async void TestDeleteOrganization()
         {
             this.httpMock.MockResponse(
                 HttpMethod.Delete,
                 $"/organizations/{this.mockOrganization.Id}",
                 HttpStatusCode.Accepted,
-                RequestUtilities.ToJsonString(this.mockOrganization));
+                "Accepted");
 
-            var response = this.service.DeleteOrganization(this.mockOrganization.Id);
+            await this.service.DeleteOrganization(this.mockOrganization.Id);
 
             this.httpMock.AssertRequestWasMade(
                 HttpMethod.Delete,


### PR DESCRIPTION
This PR fixes the `DeleteOrganization` implementation, as we don't return an Organization from the endpoint.