### PR TITLE
Fix `DeleteDirectory` implementation

### DIFF
--- a/src/WorkOS.net/Services/DirectorySync/DirectorySyncService.cs
+++ b/src/WorkOS.net/Services/DirectorySync/DirectorySyncService.cs
@@ -105,7 +105,7 @@
                 Path = $"/directories/{id}",
             };
 
-            await this.Client.MakeAPIRequest<Directory>(request, cancellationToken);
+            await this.Client.MakeRawAPIRequest(request, cancellationToken);
         }
 
         /// <summary>

--- a/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
+++ b/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
@@ -112,15 +112,15 @@
         }
 
         [Fact]
-        public void TestDeleteDirectory()
+        public async void TestDeleteDirectory()
         {
             this.httpMock.MockResponse(
                 HttpMethod.Delete,
                 $"/directories/{this.mockDirectory.Id}",
                 HttpStatusCode.Accepted,
-                RequestUtilities.ToJsonString(this.mockDirectory));
+                "Accepted");
 
-            var response = this.service.DeleteDirectory(this.mockDirectory.Id);
+            await this.service.DeleteDirectory(this.mockDirectory.Id);
 
             this.httpMock.AssertRequestWasMade(
                 HttpMethod.Delete,


### PR DESCRIPTION
This PR fixes an issue with the implementation of the `DeleteDirectory` method where it would fail to parse the API response (since we don't return a Directory from the `DELETE /directories/:id` endpoint).