### PR TITLE
Expose expires_in parameter when creating passwordless sessions

### DIFF
--- a/src/WorkOS.net/Services/Passwordless/_interfaces/CreatePasswordlessSessionOptions.cs
+++ b/src/WorkOS.net/Services/Passwordless/_interfaces/CreatePasswordlessSessionOptions.cs
@@ -36,6 +36,15 @@
         public string Connection { get; set; }
 
         /// <summary>
+        /// An optional parameter. The number of seconds the Passwordless
+        /// Session should live before expiring.
+        /// This value must be between 300 (5 minutes) and 1800 (30 minutes),
+        /// inclusive.
+        /// </summary>
+        [JsonProperty("expires_in")]
+        public int ExpiresIn { get; set; }
+
+        /// <summary>
         /// An optional parameter to encode information throughout the
         /// authentication life cycle.
         /// </summary>

--- a/src/WorkOS.net/Services/Passwordless/_interfaces/CreatePasswordlessSessionOptions.cs
+++ b/src/WorkOS.net/Services/Passwordless/_interfaces/CreatePasswordlessSessionOptions.cs
@@ -41,8 +41,8 @@
         /// This value must be between 300 (5 minutes) and 1800 (30 minutes),
         /// inclusive.
         /// </summary>
-        [JsonProperty("expires_in")]
-        public int ExpiresIn { get; set; }
+        [JsonProperty("expires_in", NullValueHandling = NullValueHandling.Ignore)]
+        public int? ExpiresIn { get; set; }
 
         /// <summary>
         /// An optional parameter to encode information throughout the


### PR DESCRIPTION
https://linear.app/workos/issue/SDK-209/expose-expires-in-parameter-when-creating-passwordless-sessions-in-net