### PR TITLE
Add Auth0SAML as a supported ConnectionType

### DIFF
--- a/src/WorkOS.net/Services/SSO/Enums/ConnectionType.cs
+++ b/src/WorkOS.net/Services/SSO/Enums/ConnectionType.cs
@@ -17,7 +17,7 @@
         Auth0SAML,
 
         [EnumMember(Value = "AzureSAML")]
-        AzureSAML, 
+        AzureSAML,
 
         [EnumMember(Value = "GenericOIDC")]
         GenericOIDC,

--- a/src/WorkOS.net/Services/SSO/Enums/ConnectionType.cs
+++ b/src/WorkOS.net/Services/SSO/Enums/ConnectionType.cs
@@ -13,8 +13,11 @@
         [EnumMember(Value = "ADFSSAML")]
         ADFSSAML,
 
+        [EnumMember(Value = "Auth0SAML")]
+        Auth0SAML,
+
         [EnumMember(Value = "AzureSAML")]
-        AzureSAML,
+        AzureSAML, 
 
         [EnumMember(Value = "GenericOIDC")]
         GenericOIDC,


### PR DESCRIPTION
The WorkOS .NET SDK isn't compatible with profiles that have an Auth0SAML connection type because it's unable to serialize due to a missing `Auth0SAML` enum value on `ConnectionType`. This PR resolves that issue.