### PR TITLE
Add connection type enums for connections added after October 2020 

### DIFF
--- a/src/WorkOS.net/Services/SSO/Enums/ConnectionType.cs
+++ b/src/WorkOS.net/Services/SSO/Enums/ConnectionType.cs
@@ -19,6 +19,9 @@
         [EnumMember(Value = "AzureSAML")]
         AzureSAML,
 
+        [EnumMember(Value = "CyberArkSAML")]
+        CyberArkSAML,
+
         [EnumMember(Value = "GenericOIDC")]
         GenericOIDC,
 
@@ -27,6 +30,12 @@
 
         [EnumMember(Value = "GoogleOAuth")]
         GoogleOAuth,
+
+        [EnumMember(Value = "GoogleSAML")]
+        GoogleSAML,
+
+        [EnumMember(Value = "JumpCloudSAML")]
+        JumpCloudSAML,
 
         [EnumMember(Value = "MagicLink")]
         MagicLink,
@@ -42,6 +51,9 @@
 
         [EnumMember(Value = "PingOneSAML")]
         PingOneSAML,
+
+        [EnumMember(Value = "SalesforceSAML")]
+        SalesforceSAML,
 
         [EnumMember(Value = "VMwareSAML")]
         VMwareSAML,


### PR DESCRIPTION
Connection Types were out of date, these need to be listed in the enum file. Added the new connections:

cyberark, googlesaml, salesforce, and jumpcloud

to reflect what's shown in this doc https://workos.com/docs/reference/sso/connection