### PR TITLE
Add created_at and updated_at fields

### DIFF
--- a/src/WorkOS.net/Services/DirectorySync/Entities/Directory.cs
+++ b/src/WorkOS.net/Services/DirectorySync/Entities/Directory.cs
@@ -59,5 +59,17 @@
         /// </summary>
         [JsonProperty("environment_id")]
         public string EnvironmentId { get; set; }
+
+        /// <summary>
+        /// The timestamp of when the Directory was created.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public string CreatedAt { get; set; }
+
+        /// <summary>
+        /// The timestamp of when the Directory was updated.
+        /// </summary>
+        [JsonProperty("updated_at")]
+        public string UpdatedAt { get; set; }
     }
 }

--- a/src/WorkOS.net/Services/Organizations/Entities/Organization.cs
+++ b/src/WorkOS.net/Services/Organizations/Entities/Organization.cs
@@ -30,5 +30,17 @@
         /// </summary>
         [JsonProperty("domains")]
         public OrganizationDomain[] Domains { get; set; }
+
+        /// <summary>
+        /// The timestamp of when the Organization was created.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public string CreatedAt { get; set; }
+
+        /// <summary>
+        /// The timestamp of when the Organization was updated.
+        /// </summary>
+        [JsonProperty("updated_at")]
+        public string UpdatedAt { get; set; }
     }
 }

--- a/src/WorkOS.net/Services/SSO/Entities/Connection.cs
+++ b/src/WorkOS.net/Services/SSO/Entities/Connection.cs
@@ -56,5 +56,17 @@
         /// </summary>
         [JsonProperty("domains")]
         public ConnectionDomain[] Domains { get; set; }
+
+        /// <summary>
+        /// The timestamp of when the Connection was created.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public string CreatedAt { get; set; }
+
+        /// <summary>
+        /// The timestamp of when the Connection was updated.
+        /// </summary>
+        [JsonProperty("updated_at")]
+        public string UpdatedAt { get; set; }
     }
 }

--- a/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
+++ b/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
@@ -61,8 +61,8 @@
                 ExternalKey = "external-key",
                 EnvironmentId = "environment_123",
                 OrganizationId = "organization_123",
-                CreatedAt = "10-04-19 12:00:17",
-                UpdatedAt = "10-04-19 12:00:17",
+                CreatedAt = "2021-07-26T18:55:16.072Z",
+                UpdatedAt = "2021-07-26T18:55:16.072Z",
             };
 
             this.mockUser = new User

--- a/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
+++ b/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
@@ -61,6 +61,8 @@
                 ExternalKey = "external-key",
                 EnvironmentId = "environment_123",
                 OrganizationId = "organization_123",
+                CreatedAt = "yyyy-MM-dd HH:mm:ss.SSS",
+                UpdatedAt = "yyyy-MM-dd HH:mm:ss.SSS",
             };
 
             this.mockUser = new User

--- a/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
+++ b/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
@@ -61,8 +61,8 @@
                 ExternalKey = "external-key",
                 EnvironmentId = "environment_123",
                 OrganizationId = "organization_123",
-                CreatedAt = "yyyy-MM-dd HH:mm:ss.SSS",
-                UpdatedAt = "yyyy-MM-dd HH:mm:ss.SSS",
+                CreatedAt = "10-04-19 12:00:17",
+                UpdatedAt = "10-04-19 12:00:17",
             };
 
             this.mockUser = new User

--- a/test/WorkOSTests/Services/Organizations/OrganizationsServiceTest.cs
+++ b/test/WorkOSTests/Services/Organizations/OrganizationsServiceTest.cs
@@ -72,8 +72,8 @@ namespace WorkOSTests
                         Domain = "foo-corp.com",
                     },
                 },
-                CreatedAt = "10-04-19 12:00:17",
-                UpdatedAt = "10-04-19 12:00:17",
+                CreatedAt = "2021-07-26T18:55:16.072Z",
+                UpdatedAt = "2021-07-26T18:55:16.072Z",
             };
         }
 

--- a/test/WorkOSTests/Services/Organizations/OrganizationsServiceTest.cs
+++ b/test/WorkOSTests/Services/Organizations/OrganizationsServiceTest.cs
@@ -72,6 +72,8 @@ namespace WorkOSTests
                         Domain = "foo-corp.com",
                     },
                 },
+                CreatedAt = "yyyy-MM-dd HH:mm:ss.SSS",
+                UpdatedAt = "yyyy-MM-dd HH:mm:ss.SSS",
             };
         }
 

--- a/test/WorkOSTests/Services/Organizations/OrganizationsServiceTest.cs
+++ b/test/WorkOSTests/Services/Organizations/OrganizationsServiceTest.cs
@@ -72,8 +72,8 @@ namespace WorkOSTests
                         Domain = "foo-corp.com",
                     },
                 },
-                CreatedAt = "yyyy-MM-dd HH:mm:ss.SSS",
-                UpdatedAt = "yyyy-MM-dd HH:mm:ss.SSS",
+                CreatedAt = "10-04-19 12:00:17",
+                UpdatedAt = "10-04-19 12:00:17",
             };
         }
 

--- a/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
+++ b/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
@@ -41,8 +41,8 @@
                 Name = "Foo Corp",
                 State = ConnectionState.Active,
                 ConnectionType = ConnectionType.OktaSAML,
-                CreatedAt = "10-04-19 12:00:17",
-                UpdatedAt = "10-04-19 12:00:17",
+                CreatedAt = "2021-07-26T18:55:16.072Z",
+                UpdatedAt = "2021-07-26T18:55:16.072Z",
             };
         }
 

--- a/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
+++ b/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
@@ -41,8 +41,8 @@
                 Name = "Foo Corp",
                 State = ConnectionState.Active,
                 ConnectionType = ConnectionType.OktaSAML,
-                CreatedAt = "yyyy-MM-dd HH:mm:ss.SSS",
-                UpdatedAt = "yyyy-MM-dd HH:mm:ss.SSS",
+                CreatedAt = "10-04-19 12:00:17",
+                UpdatedAt = "10-04-19 12:00:17",
             };
         }
 

--- a/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
+++ b/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
@@ -41,6 +41,8 @@
                 Name = "Foo Corp",
                 State = ConnectionState.Active,
                 ConnectionType = ConnectionType.OktaSAML,
+                CreatedAt = "yyyy-MM-dd HH:mm:ss.SSS",
+                UpdatedAt = "yyyy-MM-dd HH:mm:ss.SSS",
             };
         }
 


### PR DESCRIPTION
https://linear.app/workos/issue/SDK-251/add-created-at-and-updated-at-fields-to-net-sdk

Adds `created_at` and `updated_at` fields to Connections, Directories and Organizations.