### PR TITLE
Add support for `AllowProfilesOutsideOrganization` for organizations

### DIFF
--- a/src/WorkOS.net/Services/Organizations/Entities/Organization.cs
+++ b/src/WorkOS.net/Services/Organizations/Entities/Organization.cs
@@ -26,6 +26,13 @@
         public string Name { get; set; }
 
         /// <summary>
+        /// Whether Connections within the Organization allow profiles that are
+        /// outside of the Organization's configured User Email Domains.
+        /// </summary>
+        [JsonProperty("allow_profiles_outside_organization")]
+        public bool AllowProfilesOutsideOrganization { get; set; }
+
+        /// <summary>
         /// The Organization's domains.
         /// </summary>
         [JsonProperty("domains")]

--- a/src/WorkOS.net/Services/Organizations/_interfaces/CreateOrganizationOptions.cs
+++ b/src/WorkOS.net/Services/Organizations/_interfaces/CreateOrganizationOptions.cs
@@ -8,15 +8,22 @@
     public class CreateOrganizationOptions : BaseOptions
     {
         /// <summary>
-        /// Domains of the <see cref="Organization"/>.
-        /// </summary>
-        [JsonProperty("domains")]
-        public string[] Domains { get; set; }
-
-        /// <summary>
         /// Name of the <see cref="Organization"/>.
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
+
+        /// <summary>
+        /// Whether Connections within the Organization allow profiles that are
+        /// outside of the Organization's configured User Email Domains.
+        /// </summary>
+        [JsonProperty("allow_profiles_outside_organization")]
+        public bool? AllowProfilesOutsideOrganization { get; set; }
+
+        /// <summary>
+        /// Domains of the <see cref="Organization"/>.
+        /// </summary>
+        [JsonProperty("domains")]
+        public string[] Domains { get; set; }
     }
 }

--- a/src/WorkOS.net/Services/Organizations/_interfaces/UpdateOrganizationOptions.cs
+++ b/src/WorkOS.net/Services/Organizations/_interfaces/UpdateOrganizationOptions.cs
@@ -14,15 +14,22 @@ namespace WorkOS
         public string Organization { get; set; }
 
         /// <summary>
-        /// Domains of the <see cref="Organization"/>.
-        /// </summary>
-        [JsonProperty("domains")]
-        public string[] Domains { get; set; }
-
-        /// <summary>
         /// Name of the <see cref="Organization"/>.
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
+
+        /// <summary>
+        /// Whether Connections within the Organization allow profiles that are
+        /// outside of the Organization's configured User Email Domains.
+        /// </summary>
+        [JsonProperty("allow_profiles_outside_organization")]
+        public bool? AllowProfilesOutsideOrganization { get; set; }
+
+        /// <summary>
+        /// Domains of the <see cref="Organization"/>.
+        /// </summary>
+        [JsonProperty("domains")]
+        public string[] Domains { get; set; }
     }
 }

--- a/test/WorkOSTests/Services/Organizations/OrganizationsServiceTest.cs
+++ b/test/WorkOSTests/Services/Organizations/OrganizationsServiceTest.cs
@@ -64,6 +64,7 @@ namespace WorkOSTests
             {
                 Id = "org_123",
                 Name = "Foo Corp",
+                AllowProfilesOutsideOrganization = false,
                 Domains = new OrganizationDomain[]
                 {
                     new OrganizationDomain


### PR DESCRIPTION
This PR adds support for the `AllowProfilesOutsideOrganization` field for organization objects and operations.

Resolves SDK-260.