### PR TITLE
Expose `OrganizationId` on profiles

### DIFF
--- a/src/WorkOS.net/Services/SSO/Entities/Profile.cs
+++ b/src/WorkOS.net/Services/SSO/Entities/Profile.cs
@@ -21,6 +21,12 @@
         public string IdpId { get; set; }
 
         /// <summary>
+        /// The identifier for the <see cref="Organization"/> associated with the Profile.
+        /// </summary>
+        [JsonProperty("organization_id")]
+        public string OrganizationId { get; set; }
+
+        /// <summary>
         /// The identifier for the <see cref="Connection"/> associated with the Profile.
         /// </summary>
         [JsonProperty("connection_id")]

--- a/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
+++ b/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
@@ -139,6 +139,7 @@
             {
                 Id = "profile_0",
                 IdpId = "123",
+                OrganizationId = "org_123",
                 ConnectionId = "conn_123",
                 ConnectionType = ConnectionType.OktaSAML,
                 Email = "rick@sanchez.com",
@@ -186,6 +187,7 @@
             {
                 Id = "profile_0",
                 IdpId = "123",
+                OrganizationId = "org_123",
                 ConnectionId = "conn_123",
                 ConnectionType = ConnectionType.OktaSAML,
                 Email = "rick@sanchez.com",


### PR DESCRIPTION
This PR exposes the `OrganizationId` field on profiles.

Resolves SDK-266.