### PR TITLE
Add Get a Directory method

### DIFF
--- a/src/WorkOS.net/Services/DirectorySync/DirectorySyncService.cs
+++ b/src/WorkOS.net/Services/DirectorySync/DirectorySyncService.cs
@@ -27,6 +27,25 @@
         }
 
         /// <summary>
+        /// Gets a Directory.
+        /// </summary>
+        /// <param name="id">Directory unique identifier.</param>
+        /// <param name="cancellationToken">
+        /// An optional token to cancel the request.
+        /// </param>
+        /// <returns>A WorkOS Directory record.</returns>
+        public async Task<Directory> GetDirectory(string id, CancellationToken cancellationToken = default)
+        {
+            var request = new WorkOSRequest
+            {
+                Method = HttpMethod.Get,
+                Path = $"/directories/{id}",
+            };
+
+            return await this.Client.MakeAPIRequest<Directory>(request, cancellationToken);
+        }
+
+        /// <summary>
         /// Fetches a list of Directories.
         /// </summary>
         /// <param name="options">Filter options when searching for Directories.</param>

--- a/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
+++ b/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
@@ -103,6 +103,25 @@
         }
 
         [Fact]
+        public async void TestGetDirectory()
+        {
+            this.httpMock.MockResponse(
+                HttpMethod.Get,
+                $"/directories/{this.mockDirectory.Id}",
+                HttpStatusCode.OK,
+                RequestUtilities.ToJsonString(this.mockDirectory));
+
+            var response = await this.service.GetDirectory(this.mockDirectory.Id);
+
+            this.httpMock.AssertRequestWasMade(
+                HttpMethod.Get,
+                $"/directories/{this.mockDirectory.Id}");
+            Assert.Equal(
+                JsonConvert.SerializeObject(this.mockDirectory),
+                JsonConvert.SerializeObject(response));
+        }
+
+        [Fact]
         public async void TestListDirectories()
         {
             var mockResponse = new WorkOSList<Directory>


### PR DESCRIPTION
https://linear.app/workos/issue/SDK-331/net-add-get-directoriesid-method

Adds a `GetDirectory` method to Directory Sync.