### PR TITLE
Add support for `organization` parameter

### DIFF
--- a/src/WorkOS.net/Services/SSO/SSOService.cs
+++ b/src/WorkOS.net/Services/SSO/SSOService.cs
@@ -34,9 +34,11 @@
         /// <returns>An Authorization URL.</returns>
         public string GetAuthorizationURL(GetAuthorizationURLOptions options)
         {
-            if (options.Domain == null && options.Provider == null && options.Connection == null)
+#pragma warning disable CS0618 // GetAuthorizationURLOptions.Domain' is obsolete: 'The Domain property is deprecated. Please use Organization instead.
+            if (options.Domain == null && options.Provider == null && options.Connection == null && options.Organization == null)
+#pragma warning restore CS0618 // GetAuthorizationURLOptions.Domain' is obsolete: 'The Domain property is deprecated. Please use Organization instead.
             {
-                throw new ArgumentNullException("Incomplete arguments. Need to specify either a 'connection', 'domain' or 'provider'.");
+                throw new ArgumentNullException("Incomplete arguments. Need to specify either a 'connection', 'organization', 'domain', or 'provider'.");
             }
 
             var query = RequestUtilities.CreateQueryString(options);

--- a/src/WorkOS.net/Services/SSO/_interfaces/GetAuthorizationURLOptions.cs
+++ b/src/WorkOS.net/Services/SSO/_interfaces/GetAuthorizationURLOptions.cs
@@ -1,5 +1,6 @@
 ﻿namespace WorkOS
 {
+    using System;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -22,6 +23,7 @@
         /// <summary>
         /// The Enterprise's domain.
         /// </summary>
+        [Obsolete("The Domain property is deprecated. Please use Organization instead.", error: false)]
         [JsonProperty("domain")]
         public string Domain { get; set; }
 
@@ -30,6 +32,12 @@
         /// </summary>
         [JsonProperty("connection")]
         public string Connection { get; set; }
+
+        /// <summary>
+        /// The unique identifier for an <see cref="Organization"/> record.
+        /// </summary>
+        [JsonProperty("organization")]
+        public string Organization { get; set; }
 
         /// <summary>
         /// An optional parameter that specifies the type of Connection to

--- a/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
+++ b/test/WorkOSTests/Services/SSO/SSOServiceTest.cs
@@ -82,14 +82,18 @@
             var options = new GetAuthorizationURLOptions
             {
                 ClientId = "client_123",
+#pragma warning disable CS0618 // GetAuthorizationURLOptions.Domain' is obsolete: 'The Domain property is deprecated. Please use Organization instead.
                 Domain = "foo-corp.com",
+#pragma warning restore CS0618 // GetAuthorizationURLOptions.Domain' is obsolete: 'The Domain property is deprecated. Please use Organization instead.
                 RedirectURI = "https://example.com/sso/callback",
             };
             string url = this.service.GetAuthorizationURL(options);
 
             Dictionary<string, string> parameters = RequestUtilities.ParseURLParameters(url);
             Assert.Equal(options.ClientId, parameters["client_id"]);
+#pragma warning disable CS0618 // GetAuthorizationURLOptions.Domain' is obsolete: 'The Domain property is deprecated. Please use Organization instead.
             Assert.Equal(options.Domain, parameters["domain"]);
+#pragma warning restore CS0618 // GetAuthorizationURLOptions.Domain' is obsolete: 'The Domain property is deprecated. Please use Organization instead.
             Assert.Equal(options.RedirectURI, parameters["redirect_uri"]);
             Assert.Equal("code", parameters["response_type"]);
         }
@@ -113,12 +117,30 @@
         }
 
         [Fact]
+        public void TestGetAuthorizationURLWithOrganization()
+        {
+            var options = new GetAuthorizationURLOptions
+            {
+                ClientId = "client_123",
+                Organization = "organization_123",
+                RedirectURI = "https://example.com/sso/callback",
+            };
+            string url = this.service.GetAuthorizationURL(options);
+
+            Dictionary<string, string> parameters = RequestUtilities.ParseURLParameters(url);
+            Assert.Equal(options.ClientId, parameters["client_id"]);
+            Assert.Equal(options.Organization, parameters["organization"]);
+            Assert.Equal(options.RedirectURI, parameters["redirect_uri"]);
+            Assert.Equal("code", parameters["response_type"]);
+        }
+
+        [Fact]
         public void TestGetAuthorizationURLWithState()
         {
             var options = new GetAuthorizationURLOptions
             {
                 ClientId = "client_123",
-                Domain = "foo-corp.com",
+                Organization = "organization_123",
                 RedirectURI = "https://example.com/sso/callback",
                 State = "state",
             };
@@ -126,7 +148,7 @@
 
             Dictionary<string, string> parameters = RequestUtilities.ParseURLParameters(url);
             Assert.Equal(options.ClientId, parameters["client_id"]);
-            Assert.Equal(options.Domain, parameters["domain"]);
+            Assert.Equal(options.Organization, parameters["organization"]);
             Assert.Equal(options.RedirectURI, parameters["redirect_uri"]);
             Assert.Equal(options.State, parameters["state"]);
             Assert.Equal("code", parameters["response_type"]);


### PR DESCRIPTION
This PR adds support for the `organization` parameter to initiate SSO.

As part of this, the `domain` parameter has also been deprecated in favor of `organization`.

Resolves SDK-358.