### PR TITLE
Remove "suspended" state from Directory Sync user object

### DIFF
--- a/src/WorkOS.net/Services/DirectorySync/Enums/DirectoryUserState.cs
+++ b/src/WorkOS.net/Services/DirectorySync/Enums/DirectoryUserState.cs
@@ -14,7 +14,5 @@
         Active,
         [EnumMember(Value = "inactive")]
         Inactive,
-        [EnumMember(Value = "suspended")]
-        Suspended,
     }
 }


### PR DESCRIPTION
## Description
"suspended" state is now deprecated and consolidated into the "inactive" state

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
