### PR TITLE
Remove "domain" as directory query param

### DIFF
--- a/src/WorkOS.net/Services/DirectorySync/_interfaces/ListDirectoriesOptions.cs
+++ b/src/WorkOS.net/Services/DirectorySync/_interfaces/ListDirectoriesOptions.cs
@@ -8,12 +8,6 @@
     public class ListDirectoriesOptions : ListOptions
     {
         /// <summary>
-        /// Domain of a <see cref="Directory"/>. Can be empty.
-        /// </summary>
-        [JsonProperty("domain")]
-        public string Domain { get; set; }
-
-        /// <summary>
         /// Searchable text for a <see cref="Directory"/>. Can be empty.
         /// </summary>
         [JsonProperty("search")]

--- a/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
+++ b/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
@@ -38,7 +38,7 @@
 
             this.listDirectoriesOptions = new ListDirectoriesOptions
             {
-                OrganizationId = "organization_123"
+                OrganizationId = "organization_123",
             };
 
             this.listUsersOptions = new ListDirectoryUsersOptions

--- a/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
+++ b/test/WorkOSTests/Services/DirectorySync/DirectorySyncServiceTest.cs
@@ -38,7 +38,7 @@
 
             this.listDirectoriesOptions = new ListDirectoriesOptions
             {
-                Domain = "foo-corp.com",
+                OrganizationId = "organization_123"
             };
 
             this.listUsersOptions = new ListDirectoryUsersOptions


### PR DESCRIPTION
## Description
We no longer filter directories by domain

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
