### PR TITLE
Add GET /organization/:orgId/roles support

### DIFF
--- a/src/WorkOS.net/Services/Organizations/OrganizationsService.cs
+++ b/src/WorkOS.net/Services/Organizations/OrganizationsService.cs
@@ -139,5 +139,22 @@ namespace WorkOS
 
             return await this.Client.MakeAPIRequest<Organization>(request, cancellationToken);
         }
+
+        /// <summary>
+        /// Fetches a list of Roles for the Organization.
+        /// </summary>
+        /// <param name="organizationId">Organization to fetch Roles for.</param>
+        /// <returns>A list of Roles.</returns>
+        public async Task<WorkOSList<Role>> ListOrganizationRoles(
+            string organizationId)
+        {
+            var request = new WorkOSRequest
+            {
+                Method = HttpMethod.Get,
+                Path = $"/organizations/{organizationId}/roles",
+            };
+
+            return await this.Client.MakeAPIRequest<WorkOSList<Role>>(request);
+        }
     }
 }

--- a/src/WorkOS.net/Services/Roles/Entities/Role.cs
+++ b/src/WorkOS.net/Services/Roles/Entities/Role.cs
@@ -1,0 +1,58 @@
+﻿namespace WorkOS
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Contains information about a WorkOS Role record.
+    /// </summary>
+    public class Role
+    {
+        /// <summary>
+        /// Description of the record.
+        /// </summary>
+        [JsonProperty("object")]
+        public const string Object = "role";
+
+        /// <summary>
+        /// The Role's identifier.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The Role's name.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The Role's slug.
+        /// </summary>
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+
+        /// <summary>
+        /// The Role's description.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The Role's type.
+        /// </summary>
+        [JsonProperty("type")]
+        public RoleType Type { get; set; }
+
+        /// <summary>
+        /// The timestamp of when the Organization was created.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public string CreatedAt { get; set; }
+
+        /// <summary>
+        /// The timestamp of when the Organization was updated.
+        /// </summary>
+        [JsonProperty("updated_at")]
+        public string UpdatedAt { get; set; }
+    }
+}

--- a/src/WorkOS.net/Services/Roles/Entities/Role.cs
+++ b/src/WorkOS.net/Services/Roles/Entities/Role.cs
@@ -44,13 +44,13 @@
         public RoleType Type { get; set; }
 
         /// <summary>
-        /// The timestamp of when the Organization was created.
+        /// The timestamp of when the Role was created.
         /// </summary>
         [JsonProperty("created_at")]
         public string CreatedAt { get; set; }
 
         /// <summary>
-        /// The timestamp of when the Organization was updated.
+        /// The timestamp of when the Role was updated.
         /// </summary>
         [JsonProperty("updated_at")]
         public string UpdatedAt { get; set; }

--- a/src/WorkOS.net/Services/Roles/Enums/RoleType.cs
+++ b/src/WorkOS.net/Services/Roles/Enums/RoleType.cs
@@ -1,0 +1,19 @@
+namespace WorkOS
+{
+    using System.Runtime.Serialization;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    /// <summary>
+    /// An enum describing the type of a Role.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum RoleType
+    {
+        [EnumMember(Value = "EnvironmentRole")]
+        Environment,
+
+        [EnumMember(Value = "OrganizationRole")]
+        Organization,
+    }
+}

--- a/test/WorkOSTests/Services/Organizations/OrganizationsServiceTest.cs
+++ b/test/WorkOSTests/Services/Organizations/OrganizationsServiceTest.cs
@@ -22,6 +22,8 @@ namespace WorkOSTests
 
         private readonly Organization mockOrganization;
 
+        private readonly Role mockRole;
+
         public OrganizationsServiceTest()
         {
             this.httpMock = new HttpMock();
@@ -81,6 +83,17 @@ namespace WorkOSTests
                         Domain = "foo-corp.com",
                     },
                 },
+                CreatedAt = "2021-07-26T18:55:16.072Z",
+                UpdatedAt = "2021-07-26T18:55:16.072Z",
+            };
+
+            this.mockRole = new Role
+            {
+                Id = "role_123",
+                Name = "Admin",
+                Slug = "admin",
+                Description = "Admin role",
+                Type = RoleType.Organization,
                 CreatedAt = "2021-07-26T18:55:16.072Z",
                 UpdatedAt = "2021-07-26T18:55:16.072Z",
             };
@@ -244,6 +257,29 @@ namespace WorkOSTests
             this.httpMock.AssertRequestWasMade(HttpMethod.Put, $"/organizations/{updateOrganizationOptions.Organization}");
             Assert.Equal(
                 JsonConvert.SerializeObject(this.mockOrganization),
+                JsonConvert.SerializeObject(response));
+        }
+
+        [Fact]
+        public async void TestListOrganizationRoles()
+        {
+            var mockResponse = new WorkOSList<Role>
+            {
+                Data = new List<Role>
+                {
+                    this.mockRole,
+                },
+            };
+            this.httpMock.MockResponse(
+                HttpMethod.Get,
+                $"/organizations/{this.mockOrganization.Id}/roles",
+                HttpStatusCode.OK,
+                RequestUtilities.ToJsonString(mockResponse));
+            var response = await this.service.ListOrganizationRoles(this.mockOrganization.Id);
+
+            this.httpMock.AssertRequestWasMade(HttpMethod.Get, $"/organizations/{this.mockOrganization.Id}/roles");
+            Assert.Equal(
+                JsonConvert.SerializeObject(mockResponse),
                 JsonConvert.SerializeObject(response));
         }
     }


### PR DESCRIPTION
## Description
Add GET /organization/:orgId/roles support.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
