### PR TITLE
fix: Correct request param placement for POST endpoints

### DIFF
--- a/src/WorkOS.net/Client/Utilities/RequestUtilities.cs
+++ b/src/WorkOS.net/Client/Utilities/RequestUtilities.cs
@@ -77,7 +77,7 @@ namespace WorkOS
                     var jobj = JObject.Parse(jsonOptions);
                     foreach (var kvp in request.ExtraBodyParams)
                     {
-                        jobj[kvp.Key] = kvp.Value;
+                        jobj[kvp.Key] = JToken.FromObject(kvp.Value, JsonSerializer.Create(JsonSettings));
                     }
 
                     jsonOptions = jobj.ToString(Formatting.None);

--- a/src/WorkOS.net/Client/Utilities/RequestUtilities.cs
+++ b/src/WorkOS.net/Client/Utilities/RequestUtilities.cs
@@ -14,6 +14,7 @@ namespace WorkOS
     using System.Reflection;
     using System.Text;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
     using Newtonsoft.Json.Serialization;
 
     /// <summary>
@@ -67,6 +68,21 @@ namespace WorkOS
             if (request.IsJsonContentType)
             {
                 var jsonOptions = ToJsonString(options);
+
+                // Merge extra body params (from parameter-group dispatch) into
+                // the serialized JSON so that fields like password / password_hash
+                // appear as top-level body keys instead of query parameters.
+                if (request.ExtraBodyParams != null && request.ExtraBodyParams.Count > 0)
+                {
+                    var jobj = JObject.Parse(jsonOptions);
+                    foreach (var kvp in request.ExtraBodyParams)
+                    {
+                        jobj[kvp.Key] = kvp.Value;
+                    }
+
+                    jsonOptions = jobj.ToString(Formatting.None);
+                }
+
                 var content = new StringContent(jsonOptions, Encoding.UTF8);
                 content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
                 return content;

--- a/src/WorkOS.net/Client/WorkOSClient.cs
+++ b/src/WorkOS.net/Client/WorkOSClient.cs
@@ -291,6 +291,8 @@ namespace WorkOS
                 AccessToken = request.AccessToken,
                 Options = workingOptions,
                 RequestOptions = request.RequestOptions,
+                ExtraQueryParams = request.ExtraQueryParams,
+                ExtraBodyParams = request.ExtraBodyParams,
             };
 
             string? afterCursor = null;

--- a/src/WorkOS.net/Client/_interfaces/WorkOSRequest.cs
+++ b/src/WorkOS.net/Client/_interfaces/WorkOSRequest.cs
@@ -57,7 +57,7 @@ namespace WorkOS
         /// (e.g. password variants for user creation). These are merged
         /// into the JSON request body alongside the options-derived fields.
         /// </summary>
-        internal Dictionary<string, string>? ExtraBodyParams { get; set; }
+        internal Dictionary<string, object>? ExtraBodyParams { get; set; }
 
         /// <summary>
         /// Append an extra query parameter to the request.
@@ -70,11 +70,12 @@ namespace WorkOS
 
         /// <summary>
         /// Append an extra body parameter to the request. The value is
-        /// merged into the serialized JSON body.
+        /// merged into the serialized JSON body. Accepts strings, arrays,
+        /// or other objects that will be serialized as their native JSON type.
         /// </summary>
-        internal void AddBodyParam(string key, string value)
+        internal void AddBodyParam(string key, object value)
         {
-            this.ExtraBodyParams ??= new Dictionary<string, string>();
+            this.ExtraBodyParams ??= new Dictionary<string, object>();
             this.ExtraBodyParams[key] = value;
         }
     }

--- a/src/WorkOS.net/Client/_interfaces/WorkOSRequest.cs
+++ b/src/WorkOS.net/Client/_interfaces/WorkOSRequest.cs
@@ -53,12 +53,29 @@ namespace WorkOS
         internal Dictionary<string, string>? ExtraQueryParams { get; set; }
 
         /// <summary>
+        /// Extra body parameters injected by parameter-group dispatch
+        /// (e.g. password variants for user creation). These are merged
+        /// into the JSON request body alongside the options-derived fields.
+        /// </summary>
+        internal Dictionary<string, string>? ExtraBodyParams { get; set; }
+
+        /// <summary>
         /// Append an extra query parameter to the request.
         /// </summary>
         internal void AddQueryParam(string key, string value)
         {
             this.ExtraQueryParams ??= new Dictionary<string, string>();
             this.ExtraQueryParams[key] = value;
+        }
+
+        /// <summary>
+        /// Append an extra body parameter to the request. The value is
+        /// merged into the serialized JSON body.
+        /// </summary>
+        internal void AddBodyParam(string key, string value)
+        {
+            this.ExtraBodyParams ??= new Dictionary<string, string>();
+            this.ExtraBodyParams[key] = value;
         }
     }
 }

--- a/src/WorkOS.net/Services/Authorization/AuthorizationService.cs
+++ b/src/WorkOS.net/Services/Authorization/AuthorizationService.cs
@@ -301,19 +301,19 @@ namespace WorkOS
             {
                 if (byId.ResourceId != null)
                 {
-                    request.AddBodyParam("resource_id", byId.ResourceId);
+                    request.AddQueryParam("resource_id", byId.ResourceId);
                 }
             }
             else if (options?.ResourceTarget is AuthorizationResourceTargetByExternalId byExternalId)
             {
                 if (byExternalId.ResourceExternalId != null)
                 {
-                    request.AddBodyParam("resource_external_id", byExternalId.ResourceExternalId);
+                    request.AddQueryParam("resource_external_id", byExternalId.ResourceExternalId);
                 }
 
                 if (byExternalId.ResourceTypeSlug != null)
                 {
-                    request.AddBodyParam("resource_type_slug", byExternalId.ResourceTypeSlug);
+                    request.AddQueryParam("resource_type_slug", byExternalId.ResourceTypeSlug);
                 }
             }
 

--- a/src/WorkOS.net/Services/Authorization/AuthorizationService.cs
+++ b/src/WorkOS.net/Services/Authorization/AuthorizationService.cs
@@ -47,19 +47,19 @@ namespace WorkOS
             {
                 if (byId.ResourceId != null)
                 {
-                    request.AddQueryParam("resource_id", byId.ResourceId);
+                    request.AddBodyParam("resource_id", byId.ResourceId);
                 }
             }
             else if (options?.ResourceTarget is AuthorizationResourceTargetByExternalId byExternalId)
             {
                 if (byExternalId.ResourceExternalId != null)
                 {
-                    request.AddQueryParam("resource_external_id", byExternalId.ResourceExternalId);
+                    request.AddBodyParam("resource_external_id", byExternalId.ResourceExternalId);
                 }
 
                 if (byExternalId.ResourceTypeSlug != null)
                 {
-                    request.AddQueryParam("resource_type_slug", byExternalId.ResourceTypeSlug);
+                    request.AddBodyParam("resource_type_slug", byExternalId.ResourceTypeSlug);
                 }
             }
 
@@ -254,19 +254,19 @@ namespace WorkOS
             {
                 if (byId.ResourceId != null)
                 {
-                    request.AddQueryParam("resource_id", byId.ResourceId);
+                    request.AddBodyParam("resource_id", byId.ResourceId);
                 }
             }
             else if (options?.ResourceTarget is AuthorizationResourceTargetByExternalId byExternalId)
             {
                 if (byExternalId.ResourceExternalId != null)
                 {
-                    request.AddQueryParam("resource_external_id", byExternalId.ResourceExternalId);
+                    request.AddBodyParam("resource_external_id", byExternalId.ResourceExternalId);
                 }
 
                 if (byExternalId.ResourceTypeSlug != null)
                 {
-                    request.AddQueryParam("resource_type_slug", byExternalId.ResourceTypeSlug);
+                    request.AddBodyParam("resource_type_slug", byExternalId.ResourceTypeSlug);
                 }
             }
 
@@ -301,19 +301,19 @@ namespace WorkOS
             {
                 if (byId.ResourceId != null)
                 {
-                    request.AddQueryParam("resource_id", byId.ResourceId);
+                    request.AddBodyParam("resource_id", byId.ResourceId);
                 }
             }
             else if (options?.ResourceTarget is AuthorizationResourceTargetByExternalId byExternalId)
             {
                 if (byExternalId.ResourceExternalId != null)
                 {
-                    request.AddQueryParam("resource_external_id", byExternalId.ResourceExternalId);
+                    request.AddBodyParam("resource_external_id", byExternalId.ResourceExternalId);
                 }
 
                 if (byExternalId.ResourceTypeSlug != null)
                 {
-                    request.AddQueryParam("resource_type_slug", byExternalId.ResourceTypeSlug);
+                    request.AddBodyParam("resource_type_slug", byExternalId.ResourceTypeSlug);
                 }
             }
 
@@ -552,19 +552,19 @@ namespace WorkOS
             {
                 if (byId.ParentResourceId != null)
                 {
-                    request.AddQueryParam("parent_resource_id", byId.ParentResourceId);
+                    request.AddBodyParam("parent_resource_id", byId.ParentResourceId);
                 }
             }
             else if (options?.ParentResource is AuthorizationParentResourceByExternalId byExternalId)
             {
                 if (byExternalId.ParentResourceExternalId != null)
                 {
-                    request.AddQueryParam("parent_resource_external_id", byExternalId.ParentResourceExternalId);
+                    request.AddBodyParam("parent_resource_external_id", byExternalId.ParentResourceExternalId);
                 }
 
                 if (byExternalId.ParentResourceTypeSlug != null)
                 {
-                    request.AddQueryParam("parent_resource_type_slug", byExternalId.ParentResourceTypeSlug);
+                    request.AddBodyParam("parent_resource_type_slug", byExternalId.ParentResourceTypeSlug);
                 }
             }
 
@@ -712,19 +712,19 @@ namespace WorkOS
             {
                 if (byId.ParentResourceId != null)
                 {
-                    request.AddQueryParam("parent_resource_id", byId.ParentResourceId);
+                    request.AddBodyParam("parent_resource_id", byId.ParentResourceId);
                 }
             }
             else if (options?.ParentResource is AuthorizationParentResourceByExternalId byExternalId)
             {
                 if (byExternalId.ParentResourceExternalId != null)
                 {
-                    request.AddQueryParam("parent_resource_external_id", byExternalId.ParentResourceExternalId);
+                    request.AddBodyParam("parent_resource_external_id", byExternalId.ParentResourceExternalId);
                 }
 
                 if (byExternalId.ParentResourceTypeSlug != null)
                 {
-                    request.AddQueryParam("parent_resource_type_slug", byExternalId.ParentResourceTypeSlug);
+                    request.AddBodyParam("parent_resource_type_slug", byExternalId.ParentResourceTypeSlug);
                 }
             }
 
@@ -779,19 +779,19 @@ namespace WorkOS
             {
                 if (byId.ParentResourceId != null)
                 {
-                    request.AddQueryParam("parent_resource_id", byId.ParentResourceId);
+                    request.AddBodyParam("parent_resource_id", byId.ParentResourceId);
                 }
             }
             else if (options?.ParentResource is AuthorizationParentResourceByExternalId byExternalId)
             {
                 if (byExternalId.ParentResourceExternalId != null)
                 {
-                    request.AddQueryParam("parent_resource_external_id", byExternalId.ParentResourceExternalId);
+                    request.AddBodyParam("parent_resource_external_id", byExternalId.ParentResourceExternalId);
                 }
 
                 if (byExternalId.ParentResourceTypeSlug != null)
                 {
-                    request.AddQueryParam("parent_resource_type_slug", byExternalId.ParentResourceTypeSlug);
+                    request.AddBodyParam("parent_resource_type_slug", byExternalId.ParentResourceTypeSlug);
                 }
             }
 

--- a/src/WorkOS.net/Services/UserManagement/UserManagementService.cs
+++ b/src/WorkOS.net/Services/UserManagement/UserManagementService.cs
@@ -415,17 +415,17 @@ namespace WorkOS
             {
                 if (plaintext.Password != null)
                 {
-                    request.AddQueryParam("password", plaintext.Password);
+                    request.AddBodyParam("password", plaintext.Password);
                 }
             }
             else if (options?.Password is UserManagementPasswordHashed hashed)
             {
                 if (hashed.PasswordHash != null)
                 {
-                    request.AddQueryParam("password_hash", hashed.PasswordHash);
+                    request.AddBodyParam("password_hash", hashed.PasswordHash);
                 }
 
-                request.AddQueryParam("password_hash_type", JsonConvert.SerializeObject(hashed.PasswordHashType).Trim('"'));
+                request.AddBodyParam("password_hash_type", JsonConvert.SerializeObject(hashed.PasswordHashType).Trim('"'));
             }
 
             return await this.Client.MakeAPIRequest<User>(request, cancellationToken);
@@ -498,17 +498,17 @@ namespace WorkOS
             {
                 if (plaintext.Password != null)
                 {
-                    request.AddQueryParam("password", plaintext.Password);
+                    request.AddBodyParam("password", plaintext.Password);
                 }
             }
             else if (options?.Password is UserManagementPasswordHashed hashed)
             {
                 if (hashed.PasswordHash != null)
                 {
-                    request.AddQueryParam("password_hash", hashed.PasswordHash);
+                    request.AddBodyParam("password_hash", hashed.PasswordHash);
                 }
 
-                request.AddQueryParam("password_hash_type", JsonConvert.SerializeObject(hashed.PasswordHashType).Trim('"'));
+                request.AddBodyParam("password_hash_type", JsonConvert.SerializeObject(hashed.PasswordHashType).Trim('"'));
             }
 
             return await this.Client.MakeAPIRequest<User>(request, cancellationToken);
@@ -920,14 +920,14 @@ namespace WorkOS
             {
                 if (single.RoleSlug != null)
                 {
-                    request.AddQueryParam("role_slug", single.RoleSlug);
+                    request.AddBodyParam("role_slug", single.RoleSlug);
                 }
             }
             else if (options?.Role is UserManagementRoleMultiple multiple)
             {
                 if (multiple.RoleSlugs != null)
                 {
-                    request.AddQueryParam("role_slugs", string.Join(",", multiple.RoleSlugs));
+                    request.AddBodyParam("role_slugs", string.Join(",", multiple.RoleSlugs));
                 }
             }
 
@@ -982,14 +982,14 @@ namespace WorkOS
             {
                 if (single.RoleSlug != null)
                 {
-                    request.AddQueryParam("role_slug", single.RoleSlug);
+                    request.AddBodyParam("role_slug", single.RoleSlug);
                 }
             }
             else if (options?.Role is UserManagementRoleMultiple multiple)
             {
                 if (multiple.RoleSlugs != null)
                 {
-                    request.AddQueryParam("role_slugs", string.Join(",", multiple.RoleSlugs));
+                    request.AddBodyParam("role_slugs", string.Join(",", multiple.RoleSlugs));
                 }
             }
 

--- a/src/WorkOS.net/Services/UserManagement/UserManagementService.cs
+++ b/src/WorkOS.net/Services/UserManagement/UserManagementService.cs
@@ -927,7 +927,7 @@ namespace WorkOS
             {
                 if (multiple.RoleSlugs != null)
                 {
-                    request.AddBodyParam("role_slugs", string.Join(",", multiple.RoleSlugs));
+                    request.AddBodyParam("role_slugs", multiple.RoleSlugs);
                 }
             }
 
@@ -989,7 +989,7 @@ namespace WorkOS
             {
                 if (multiple.RoleSlugs != null)
                 {
-                    request.AddBodyParam("role_slugs", string.Join(",", multiple.RoleSlugs));
+                    request.AddBodyParam("role_slugs", multiple.RoleSlugs);
                 }
             }
 


### PR DESCRIPTION
## Summary
- Parameter-group dispatch fields (passwords, resource IDs, role slugs, etc.) were incorrectly sent as query parameters on POST requests instead of in the JSON body
- Adds `ExtraBodyParams` dictionary and `AddBodyParam` method to `WorkOSRequest` for body-level parameter injection
- `RequestUtilities` now merges `ExtraBodyParams` into the serialized JSON body at request time
- Fixes `AuthorizationService` and `UserManagementService` to use `AddBodyParam` instead of `AddQueryParam` for all parameter-group dispatch fields

Closes https://github.com/workos/workos-dotnet/issues/236

## Test plan
- [ ] Verify user creation with password sends `password` in the JSON body, not as a query param
- [ ] Verify user creation with hashed password sends `password_hash` and `password_hash_type` in the body
- [ ] Verify authorization check/batch-check/list-objects send resource fields in the body
- [ ] Verify create/update organization membership sends role fields in the body