### PR TITLE
fix: Honor EnumMember attribute in query-string serialization

### DIFF
--- a/src/WorkOS.net/Client/Utilities/RequestUtilities.cs
+++ b/src/WorkOS.net/Client/Utilities/RequestUtilities.cs
@@ -12,6 +12,7 @@ namespace WorkOS
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Reflection;
+    using System.Runtime.Serialization;
     using System.Text;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
@@ -353,7 +354,7 @@ namespace WorkOS
                     rendered = dto.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
                     break;
                 case Enum en:
-                    rendered = en.ToString();
+                    rendered = ResolveEnumWireValue(en);
                     break;
                 case double d:
                     rendered = d.ToString("R", CultureInfo.InvariantCulture);
@@ -370,6 +371,26 @@ namespace WorkOS
             }
 
             result.Add(new KeyValuePair<string, string>(key, rendered));
+        }
+
+        /// <summary>
+        /// Return the wire value for an enum member by reading its
+        /// <see cref="EnumMemberAttribute.Value"/>. Falls back to
+        /// <c>ToString()</c> when the attribute is absent.
+        /// </summary>
+        private static string ResolveEnumWireValue(Enum value)
+        {
+            var member = value.GetType().GetField(value.ToString());
+            if (member != null)
+            {
+                var attr = member.GetCustomAttribute<EnumMemberAttribute>();
+                if (attr != null && attr.Value != null)
+                {
+                    return attr.Value;
+                }
+            }
+
+            return value.ToString();
         }
 
         /// <summary>

--- a/src/WorkOS.net/Services/_common/_interfaces/ListOptions.cs
+++ b/src/WorkOS.net/Services/_common/_interfaces/ListOptions.cs
@@ -35,6 +35,6 @@ namespace WorkOS
         /// </summary>
         [JsonProperty("order")]
         [STJS.JsonPropertyName("order")]
-        public PaginationOrder? Order { get; set; }
+        public PaginationOrder? Order { get; set; } = PaginationOrder.Desc;
     }
 }

--- a/src/WorkOS.net/Services/_common/_interfaces/ListOptions.cs
+++ b/src/WorkOS.net/Services/_common/_interfaces/ListOptions.cs
@@ -35,6 +35,6 @@ namespace WorkOS
         /// </summary>
         [JsonProperty("order")]
         [STJS.JsonPropertyName("order")]
-        public PaginationOrder Order { get; set; } = PaginationOrder.Desc;
+        public PaginationOrder? Order { get; set; }
     }
 }

--- a/test/WorkOSTests/Client/NonGetQueryParamsTest.cs
+++ b/test/WorkOSTests/Client/NonGetQueryParamsTest.cs
@@ -27,15 +27,13 @@ namespace WorkOSTests
 
             httpMock.MockResponse(
                 HttpMethod.Delete,
-                "/authorization/organizations/org_1/resources/file/ext_42",
+                "/authorization/resources/res_1",
                 HttpStatusCode.NoContent,
                 "{}");
 
-            await client.Authorization.DeleteResourceByExternalId(
-                "org_1",
-                "file",
-                "ext_42",
-                new AuthorizationDeleteResourceByExternalIdOptions { CascadeDelete = true });
+            await client.Authorization.DeleteResource(
+                "res_1",
+                new AuthorizationDeleteResourceOptions { CascadeDelete = true });
 
             var last = Assert.Single(httpMock.CapturedRequests);
             Assert.Equal(HttpMethod.Delete, last.Method);
@@ -56,15 +54,13 @@ namespace WorkOSTests
 
             httpMock.MockResponse(
                 HttpMethod.Delete,
-                "/authorization/organizations/org_1/resources/file/ext_42",
+                "/authorization/resources/res_1",
                 HttpStatusCode.NoContent,
                 "{}");
 
-            await client.Authorization.DeleteResourceByExternalId(
-                "org_1",
-                "file",
-                "ext_42",
-                new AuthorizationDeleteResourceByExternalIdOptions { CascadeDelete = false });
+            await client.Authorization.DeleteResource(
+                "res_1",
+                new AuthorizationDeleteResourceOptions { CascadeDelete = false });
 
             var last = Assert.Single(httpMock.CapturedRequests);
             Assert.Contains("cascade_delete=false", last.RequestUri!.Query);


### PR DESCRIPTION
## Summary
- Query-string serializer now reads `[EnumMember(Value="...")]` instead of falling back to `Enum.ToString()`, so enum values like `PaginationOrder.Desc` serialize as `desc` (not `Desc`) on the wire
- `ListOptions.Order` is now `PaginationOrder?` (nullable) so callers can omit the `order` query parameter entirely
- Fixes pre-existing test compilation failure in `NonGetQueryParamsTest` caused by the `DeleteResourceByExternalId` → `DeleteResource` rename

## Test plan
- [x] `dotnet build` succeeds (0 errors, 0 warnings)
- [x] `dotnet test` passes all 437 tests
- [ ] Verify against live API that `OrganizationsService.ListAsync` no longer returns a validation error for the `order` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)