### PR TITLE
chore: rename timestampSeconds to timestampMs in ActionsService

### DIFF
--- a/src/WorkOS.net/Services/Actions/ActionsService.cs
+++ b/src/WorkOS.net/Services/Actions/ActionsService.cs
@@ -47,10 +47,10 @@ namespace WorkOS
         public void VerifyHeader(string payload, string sigHeader, string secret, int tolerance = DefaultTolerance)
         {
             var (timestamp, signature) = ParseSignatureHeader(sigHeader);
-            var timestampSeconds = long.Parse(timestamp);
+            var timestampMs = long.Parse(timestamp);
             var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
-            if (Math.Abs(nowMs - timestampSeconds) > tolerance * 1000L)
+            if (Math.Abs(nowMs - timestampMs) > tolerance * 1000L)
             {
                 throw new InvalidOperationException("Timestamp outside of the tolerance zone.");
             }


### PR DESCRIPTION
## Summary
- Pure rename of a misleading local variable name in `ActionsService.VerifyHeader`. No behavior change.
- The variable was named `timestampSeconds`, but it holds the raw `t=` value parsed from the signature header — which WorkOS sends as a **millisecond** Unix timestamp — and is compared against `DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()`. So the math was already correct in milliseconds; only the name was wrong.
- Caught while auditing other backend SDKs after the recent Go SDK fix that addressed the same millisecond-vs-seconds confusion at the parsing layer (workos-go f96ac76). The other SDKs (elixir, kotlin, php, python, ruby, dotnet) all correctly treat `t=` as ms; the dotnet variable name was the only lingering rough edge.

## Test plan
- [ ] CI passes (no test changes — this is a rename within a method body)
- [ ] No callers reference the variable (it's a local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)