### PR TITLE
feat(docs): add DocFX-based API reference site

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "docfx": {
+      "version": "2.78.5",
+      "commands": [
+        "docfx"
+      ]
+    },
+    "defaultdocumentation.console": {
+      "version": "1.2.4",
+      "commands": [
+        "defaultdocumentation"
+      ]
+    }
+  }
+}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,34 @@
+name: Publish API Docs
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: pages
+  cancel-in-progress: false
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: '8.0.x'
+      - run: ./script/docs
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: docs/_site
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        id: deployment

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,9 +20,21 @@ jobs:
           dotnet-version: '8.0.x'
       - run: ./script/docs
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+      - name: Archive site
+        run: |
+          tar \
+            --dereference --hard-dereference \
+            --directory docs/_site \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            .
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          path: docs/_site
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
   deploy:
     needs: build
     environment:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ project.lock.json
 *.log
 *.swp
 
+# DocFX generated output
+docs/_site/
+api/
+

--- a/docfx.json
+++ b/docfx.json
@@ -1,0 +1,53 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "src": ".",
+          "files": [
+            "src/WorkOS.net/WorkOS.net.csproj"
+          ]
+        }
+      ],
+      "dest": "api",
+      "disableGitFeatures": false,
+      "disableDefaultFilter": false
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [
+          "api/**.yml",
+          "api/**.md"
+        ]
+      },
+      {
+        "files": [
+          "index.md",
+          "toc.yml"
+        ],
+        "src": "docfx"
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+          "images/**"
+        ],
+        "src": "docfx"
+      }
+    ],
+    "output": "docs/_site",
+    "globalMetadata": {
+      "_appName": "WorkOS .NET SDK",
+      "_appTitle": "WorkOS .NET SDK",
+      "_enableSearch": false,
+      "_disableContribution": true
+    },
+    "template": [
+      "default",
+      "modern"
+    ]
+  }
+}

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -1,0 +1,33 @@
+# WorkOS .NET SDK
+
+The official .NET client for the [WorkOS API](https://workos.com). This documentation is automatically generated from the inline XML doc comments in the SDK source code and is published with each release.
+
+## API Reference
+
+Browse the **API Reference** in the navigation above for the full set of types, methods, and modules exposed by `WorkOS.net`. The reference covers every public namespace, class, interface, struct, enum, and method available in the SDK.
+
+## Installation
+
+The package is published to NuGet. Install it into your project with the `dotnet` CLI:
+
+```sh
+dotnet add package WorkOS.net
+```
+
+## Getting started
+
+To begin making API requests, instantiate a `WorkOSClient` with your API key. The client exposes a property for each WorkOS service (User Management, SSO, Directory Sync, Audit Logs, Organizations, Webhooks, and more).
+
+```csharp
+using WorkOS;
+
+var client = new WorkOSClient("sk_example_...");
+var user = await client.UserManagement.GetUser("user_123");
+```
+
+## Resources
+
+- [WorkOS Dashboard](https://dashboard.workos.com) — manage your organization, environments, and API keys.
+- [WorkOS API Documentation](https://workos.com/docs) — REST API reference and integration guides.
+- [GitHub Repository](https://github.com/workos/workos-dotnet) — source code, issue tracker, and release notes.
+- [NuGet Package](https://www.nuget.org/packages/WorkOS.net) — published package versions.

--- a/docfx/toc.yml
+++ b/docfx/toc.yml
@@ -1,0 +1,4 @@
+- name: Home
+  href: index.md
+- name: API Reference
+  href: ../api/

--- a/script/docs
+++ b/script/docs
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+cd "$(dirname "$0")/.."
+dotnet tool restore
+dotnet docfx docfx.json
+dotnet build src/WorkOS.net/WorkOS.net.csproj -c Release
+dotnet defaultdocumentation \
+  --AssemblyFilePath src/WorkOS.net/bin/Release/net8.0/WorkOS.net.dll \
+  --DocumentationFilePath src/WorkOS.net/bin/Release/net8.0/WorkOS.net.xml \
+  --OutputDirectoryPath docs/_site/api/ \
+  --FileNameFactory FullName \
+  --GeneratedAccessModifiers Public,Protected
+
+find docs/_site/api -name '*.md' -exec sed -i.bak 's/&#129106;/->/g' {} +
+find docs/_site/api -name '*.md.bak' -delete
+
+{
+  echo "# WorkOS .NET SDK"
+  echo
+  echo "> Auto-generated API reference for the WorkOS .NET SDK. Each entry links to a raw markdown file describing a public type."
+  echo
+  echo "## API"
+  echo
+  for f in docs/_site/api/*.md; do
+    name=$(basename "$f" .md)
+    printf -- "- [%s](https://workos.github.io/workos-dotnet/api/%s.md)\n" "$name" "$name"
+  done
+} > docs/_site/llms.txt

--- a/script/docs-serve
+++ b/script/docs-serve
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+cd "$(dirname "$0")/.."
+exec dotnet docfx serve docs/_site -p 4000

--- a/src/WorkOS.net/WorkOS.net.csproj
+++ b/src/WorkOS.net/WorkOS.net.csproj
@@ -7,7 +7,7 @@
     <Authors>WorkOS</Authors>
     <Copyright>Copyright © WorkOS</Copyright>
     <PackageId>WorkOS.net</PackageId>
-    <PackageProjectUrl>https://github.com/workos-inc/workos-dotnet</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/workos/workos-dotnet</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
## Summary
- Add DocFX configuration (`docfx.json`, `docfx/index.md`, `docfx/toc.yml`) to generate a static API reference site from the XML doc comments the SDK already ships, so consumers no longer have to read source on GitHub to explore types and methods.
- Add a `.github/workflows/docs.yml` GitHub Actions workflow that publishes the generated site to GitHub Pages on every release tag, keeping the reference in lockstep with NuGet releases without manual upkeep.
- Add `script/docs` and `script/docs-serve` helpers plus `.config/dotnet-tools.json` so contributors can build and preview the site locally with a single command.
- Update `PackageProjectUrl` in `src/WorkOS.net/WorkOS.net.csproj` to the canonical `workos` GitHub org URL — the `workos-inc` org was renamed and published NuGet metadata should point at the canonical location instead of relying on the redirect.

## Test plan
- [ ] `script/docs` builds the site locally without errors
- [ ] `script/docs-serve` serves the generated site and key SDK types render with their XML doc comments
- [ ] `docs.yml` workflow runs successfully when a release tag is pushed and publishes to GitHub Pages
- [ ] NuGet package metadata shows the updated `https://github.com/workos/...` project URL after the next release