### PR TITLE
fix: hardening across webhooks, session, client, vault, passwordless

### DIFF
--- a/src/WorkOS.net/Client/WorkOSClient.cs
+++ b/src/WorkOS.net/Client/WorkOSClient.cs
@@ -176,6 +176,16 @@ namespace WorkOS
         {
             var maxRetries = request.RequestOptions?.MaxRetries ?? this.MaxRetries;
 
+            // Resolve the idempotency key once, outside the retry loop, so every
+            // attempt for a given logical request reuses the same key. Generating
+            // a fresh GUID per attempt would defeat the server-side dedup that
+            // makes retries safe.
+            var idempotencyKey = request.RequestOptions?.IdempotencyKey;
+            if (string.IsNullOrWhiteSpace(idempotencyKey) && request.Method == HttpMethod.Post)
+            {
+                idempotencyKey = Guid.NewGuid().ToString();
+            }
+
             HttpResponseMessage? response = null;
             Exception? lastException = null;
 
@@ -189,7 +199,7 @@ namespace WorkOS
 
                 // Must build a fresh HttpRequestMessage per attempt because
                 // HttpClient disposes the content after sending.
-                var requestMessage = this.CreateHttpRequestMessage(request);
+                var requestMessage = this.CreateHttpRequestMessage(request, idempotencyKey);
 
                 try
                 {
@@ -410,7 +420,7 @@ namespace WorkOS
         private static bool UsesQueryString(HttpMethod method) =>
             method == HttpMethod.Get || method == HttpMethod.Delete;
 
-        private HttpRequestMessage CreateHttpRequestMessage(WorkOSRequest request)
+        private HttpRequestMessage CreateHttpRequestMessage(WorkOSRequest request, string? idempotencyKey = null)
         {
             Uri uri = this.BuildUri(request);
             HttpContent? content = null;
@@ -436,17 +446,15 @@ namespace WorkOS
                 requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
             }
 
-            // Idempotency key: use explicit value if provided, otherwise auto-generate
-            // for POST requests to ensure safe retries (per sdk-runtime-contract §2).
-            var idempotencyKey = request.RequestOptions?.IdempotencyKey;
-            if (string.IsNullOrWhiteSpace(idempotencyKey) && request.Method == HttpMethod.Post)
+            // Idempotency key is resolved once per logical request in
+            // MakeRawAPIRequest (outside the retry loop) and passed in here so
+            // that every retry attempt sends the same value (per
+            // sdk-runtime-contract §2). Fall back to the explicit
+            // RequestOptions value for callers that invoke this directly.
+            var effectiveIdempotencyKey = idempotencyKey ?? request.RequestOptions?.IdempotencyKey;
+            if (!string.IsNullOrWhiteSpace(effectiveIdempotencyKey))
             {
-                idempotencyKey = Guid.NewGuid().ToString();
-            }
-
-            if (!string.IsNullOrWhiteSpace(idempotencyKey))
-            {
-                requestMessage.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey);
+                requestMessage.Headers.TryAddWithoutValidation("Idempotency-Key", effectiveIdempotencyKey);
             }
 
             requestMessage.Headers.TryAddWithoutValidation("User-Agent", userAgentString);

--- a/src/WorkOS.net/Services/Passwordless/PasswordlessService.cs
+++ b/src/WorkOS.net/Services/Passwordless/PasswordlessService.cs
@@ -1,6 +1,7 @@
 // @oagen-ignore-file
 namespace WorkOS
 {
+    using System;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -81,7 +82,7 @@ namespace WorkOS
             var request = new WorkOSRequest
             {
                 Method = HttpMethod.Post,
-                Path = $"/passwordless/sessions/{sessionId}/send",
+                Path = $"/passwordless/sessions/{Uri.EscapeDataString(sessionId)}/send",
                 RequestOptions = requestOptions,
             };
             await this.Client.MakeRawAPIRequest(request, cancellationToken);

--- a/src/WorkOS.net/Services/Session/SessionService.cs
+++ b/src/WorkOS.net/Services/Session/SessionService.cs
@@ -251,24 +251,28 @@ namespace WorkOS
             var config = await this.jwksManager.GetConfigurationAsync(cancellationToken);
             var handler = new JwtSecurityTokenHandler();
 
-            // Defaults are derived from the configured client. Callers can
-            // override via the additive ValidIssuer / ValidAudience /
-            // ValidAlgorithms properties for non-standard deployments.
-            // TODO: confirm the literal documented WorkOS issuer/audience
-            // strings — see security-fix-plan.md open question on .NET #57.
+            // Audience defaults to the configured clientId, which is the
+            // conventional WorkOS access-token audience. Issuer has no
+            // default — the literal WorkOS issuer string is not yet
+            // confirmed for this SDK, so issuer validation is opt-in via
+            // the additive ValidIssuer property until that is verified.
+            // ValidAudience / ValidAlgorithms remain overridable.
             var clientId = this.Client.ClientId;
-            var defaultIssuer = !string.IsNullOrEmpty(clientId)
-                ? $"{this.Client.ApiBaseURL}/user_management/{clientId}"
-                : null;
-            var effectiveIssuer = this.ValidIssuer ?? defaultIssuer;
             var effectiveAudience = this.ValidAudience ?? clientId;
+            if (string.IsNullOrEmpty(effectiveAudience))
+            {
+                throw new InvalidOperationException(
+                    "JWT audience validation requires a configured ClientId or an explicit SessionService.ValidAudience.");
+            }
+
             var effectiveAlgorithms = this.ValidAlgorithms ?? new[] { "RS256" };
+            var validateIssuer = !string.IsNullOrEmpty(this.ValidIssuer);
 
             var validationParameters = new TokenValidationParameters
             {
-                ValidateIssuer = !string.IsNullOrEmpty(effectiveIssuer),
-                ValidIssuer = effectiveIssuer,
-                ValidateAudience = !string.IsNullOrEmpty(effectiveAudience),
+                ValidateIssuer = validateIssuer,
+                ValidIssuer = this.ValidIssuer,
+                ValidateAudience = true,
                 ValidAudience = effectiveAudience,
                 ValidateLifetime = true,
                 ValidAlgorithms = effectiveAlgorithms,

--- a/src/WorkOS.net/Services/Session/SessionService.cs
+++ b/src/WorkOS.net/Services/Session/SessionService.cs
@@ -259,7 +259,9 @@ namespace WorkOS
             // upgrade. Signature + algorithm + lifetime are enforced
             // unconditionally; callers can layer on iss/aud once the
             // canonical strings for their deployment are confirmed.
-            var effectiveAlgorithms = this.ValidAlgorithms ?? new[] { "RS256" };
+            var effectiveAlgorithms = this.ValidAlgorithms is { Count: > 0 }
+                ? this.ValidAlgorithms
+                : new[] { "RS256" };
 
             var validationParameters = new TokenValidationParameters
             {

--- a/src/WorkOS.net/Services/Session/SessionService.cs
+++ b/src/WorkOS.net/Services/Session/SessionService.cs
@@ -26,6 +26,34 @@ namespace WorkOS
         {
         }
 
+        /// <summary>
+        /// Optional override for the expected JWT issuer. When null, defaults to
+        /// <c>{ApiBaseURL}/user_management/{clientId}</c>.
+        /// </summary>
+        /// <remarks>
+        /// TODO: confirm the literal documented WorkOS access-token issuer
+        /// before locking this default. See security-fix-plan.md "Open
+        /// questions / follow-ups" entry on .NET #57.
+        /// </remarks>
+        public string? ValidIssuer { get; set; }
+
+        /// <summary>
+        /// Optional override for the expected JWT audience. When null, defaults
+        /// to the configured client ID.
+        /// </summary>
+        /// <remarks>
+        /// TODO: confirm the literal documented WorkOS access-token audience
+        /// before locking this default. See security-fix-plan.md "Open
+        /// questions / follow-ups" entry on .NET #57.
+        /// </remarks>
+        public string? ValidAudience { get; set; }
+
+        /// <summary>
+        /// Optional override for the JWT signing algorithms accepted during
+        /// access-token validation. Defaults to <c>RS256</c>.
+        /// </summary>
+        public IList<string>? ValidAlgorithms { get; set; }
+
         /// <summary>Get the JWKS URL for the current client.</summary>
         /// <param name="clientId">Optional client ID override.</param>
         /// <returns>The JWKS URL string.</returns>
@@ -222,11 +250,28 @@ namespace WorkOS
 
             var config = await this.jwksManager.GetConfigurationAsync(cancellationToken);
             var handler = new JwtSecurityTokenHandler();
+
+            // Defaults are derived from the configured client. Callers can
+            // override via the additive ValidIssuer / ValidAudience /
+            // ValidAlgorithms properties for non-standard deployments.
+            // TODO: confirm the literal documented WorkOS issuer/audience
+            // strings — see security-fix-plan.md open question on .NET #57.
+            var clientId = this.Client.ClientId;
+            var defaultIssuer = !string.IsNullOrEmpty(clientId)
+                ? $"{this.Client.ApiBaseURL}/user_management/{clientId}"
+                : null;
+            var effectiveIssuer = this.ValidIssuer ?? defaultIssuer;
+            var effectiveAudience = this.ValidAudience ?? clientId;
+            var effectiveAlgorithms = this.ValidAlgorithms ?? new[] { "RS256" };
+
             var validationParameters = new TokenValidationParameters
             {
-                ValidateIssuer = false,
-                ValidateAudience = false,
+                ValidateIssuer = !string.IsNullOrEmpty(effectiveIssuer),
+                ValidIssuer = effectiveIssuer,
+                ValidateAudience = !string.IsNullOrEmpty(effectiveAudience),
+                ValidAudience = effectiveAudience,
                 ValidateLifetime = true,
+                ValidAlgorithms = effectiveAlgorithms,
                 IssuerSigningKeys = config.SigningKeys,
             };
 

--- a/src/WorkOS.net/Services/Session/SessionService.cs
+++ b/src/WorkOS.net/Services/Session/SessionService.cs
@@ -251,29 +251,22 @@ namespace WorkOS
             var config = await this.jwksManager.GetConfigurationAsync(cancellationToken);
             var handler = new JwtSecurityTokenHandler();
 
-            // Audience defaults to the configured clientId, which is the
-            // conventional WorkOS access-token audience. Issuer has no
-            // default — the literal WorkOS issuer string is not yet
-            // confirmed for this SDK, so issuer validation is opt-in via
-            // the additive ValidIssuer property until that is verified.
-            // ValidAudience / ValidAlgorithms remain overridable.
-            var clientId = this.Client.ClientId;
-            var effectiveAudience = this.ValidAudience ?? clientId;
-            if (string.IsNullOrEmpty(effectiveAudience))
-            {
-                throw new InvalidOperationException(
-                    "JWT audience validation requires a configured ClientId or an explicit SessionService.ValidAudience.");
-            }
-
+            // Issuer and audience validation are opt-in via ValidIssuer /
+            // ValidAudience. The canonical WorkOS `iss` and `aud` claim
+            // values are not documented across SDKs (workos-node validates
+            // only sig+alg+exp; Ruby/Python skip `aud`), so hard-coding a
+            // default would risk rejecting every legitimate token on
+            // upgrade. Signature + algorithm + lifetime are enforced
+            // unconditionally; callers can layer on iss/aud once the
+            // canonical strings for their deployment are confirmed.
             var effectiveAlgorithms = this.ValidAlgorithms ?? new[] { "RS256" };
-            var validateIssuer = !string.IsNullOrEmpty(this.ValidIssuer);
 
             var validationParameters = new TokenValidationParameters
             {
-                ValidateIssuer = validateIssuer,
+                ValidateIssuer = !string.IsNullOrEmpty(this.ValidIssuer),
                 ValidIssuer = this.ValidIssuer,
-                ValidateAudience = true,
-                ValidAudience = effectiveAudience,
+                ValidateAudience = !string.IsNullOrEmpty(this.ValidAudience),
+                ValidAudience = this.ValidAudience,
                 ValidateLifetime = true,
                 ValidAlgorithms = effectiveAlgorithms,
                 IssuerSigningKeys = config.SigningKeys,

--- a/src/WorkOS.net/Services/Vault/VaultService.cs
+++ b/src/WorkOS.net/Services/Vault/VaultService.cs
@@ -326,6 +326,11 @@ namespace WorkOS
             var (keyLen, bytesRead) = DecodeLeb128(combined, offset);
             offset += bytesRead;
 
+            if (keyLen > (uint)(combined.Length - offset))
+            {
+                throw new InvalidOperationException("Encrypted payload is malformed: key length exceeds remaining buffer.");
+            }
+
             var encryptedKeys = new byte[keyLen];
             Buffer.BlockCopy(combined, offset, encryptedKeys, 0, (int)keyLen);
             offset += (int)keyLen;
@@ -382,6 +387,16 @@ namespace WorkOS
             int bytesRead = 0;
             while (true)
             {
+                if (bytesRead >= 4)
+                {
+                    throw new InvalidOperationException("LEB128 length prefix exceeds 4 bytes; payload is malformed.");
+                }
+
+                if (offset + bytesRead >= data.Length)
+                {
+                    throw new InvalidOperationException("LEB128 length prefix is truncated.");
+                }
+
                 byte b = data[offset + bytesRead];
                 result |= (uint)(b & 0x7F) << shift;
                 bytesRead++;

--- a/src/WorkOS.net/Services/Webhooks/WebhookService.cs
+++ b/src/WorkOS.net/Services/Webhooks/WebhookService.cs
@@ -77,18 +77,18 @@ namespace WorkOS
         {
             if (signatureHeader == null)
             {
-                throw new ArgumentException("Unable to extract timestamp and signature hash from header");
+                throw new WorkOSWebhookException("Unable to extract timestamp and signature hash from header");
             }
 
             var timeAndSig = signatureHeader.Split(',');
             if (timeAndSig.Length != 2)
             {
-                throw new ArgumentException("Unable to extract timestamp and signature hash from header");
+                throw new WorkOSWebhookException("Unable to extract timestamp and signature hash from header");
             }
 
             if (!signatureHeader.Contains("t=") || !signatureHeader.Contains("v1="))
             {
-                throw new ArgumentException("Unable to extract timestamp and signature hash from header");
+                throw new WorkOSWebhookException("Unable to extract timestamp and signature hash from header");
             }
 
             var timeStamp = timeAndSig[0];

--- a/src/WorkOS.net/Services/Webhooks/WebhookService.cs
+++ b/src/WorkOS.net/Services/Webhooks/WebhookService.cs
@@ -118,14 +118,10 @@ namespace WorkOS
                 throw new WorkOSWebhookException("Webhook timestamp is not a valid integer.");
             }
 
-            try
-            {
-                return this.UnixTimeToDateTime(timestampMs) >= DateTime.Now.AddSeconds(tolerance * -1);
-            }
-            catch (Exception ex) when (ex is ArgumentOutOfRangeException || ex is OverflowException)
-            {
-                throw new WorkOSWebhookException("Webhook timestamp is out of representable range.");
-            }
+            // Symmetric tolerance — reject timestamps that are too far in
+            // either direction. Matches ActionsService.VerifyHeader.
+            var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            return Math.Abs(nowMs - timestampMs) <= tolerance * 1000L;
         }
 
         /// <summary>
@@ -171,11 +167,5 @@ namespace WorkOS
             return ConstantTimeAreEqual(a, b);
         }
 
-        private DateTime UnixTimeToDateTime(long unixtime)
-        {
-            DateTime dtDateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-            dtDateTime = dtDateTime.AddMilliseconds(unixtime).ToLocalTime();
-            return dtDateTime;
-        }
     }
 }

--- a/src/WorkOS.net/Services/Webhooks/WebhookService.cs
+++ b/src/WorkOS.net/Services/Webhooks/WebhookService.cs
@@ -75,13 +75,24 @@ namespace WorkOS
         /// <returns>The timestamp and signature hash.</returns>
         public (string TimeStamp, string SignatureHash) GetTimestampAndSignature(string signatureHeader)
         {
+            if (signatureHeader == null)
+            {
+                throw new ArgumentException("Unable to extract timestamp and signature hash from header");
+            }
+
             var timeAndSig = signatureHeader.Split(',');
-            var timeStamp = timeAndSig[0];
-            var signatureHash = timeAndSig[1];
+            if (timeAndSig.Length != 2)
+            {
+                throw new ArgumentException("Unable to extract timestamp and signature hash from header");
+            }
+
             if (!signatureHeader.Contains("t=") || !signatureHeader.Contains("v1="))
             {
                 throw new ArgumentException("Unable to extract timestamp and signature hash from header");
             }
+
+            var timeStamp = timeAndSig[0];
+            var signatureHash = timeAndSig[1];
 
             timeStamp = timeStamp.Substring(timeStamp.IndexOf("t=", StringComparison.Ordinal) + 2).Trim();
             signatureHash = signatureHash.Substring(signatureHash.IndexOf("v1=", StringComparison.Ordinal) + 3).Trim();
@@ -97,7 +108,24 @@ namespace WorkOS
         /// <returns><c>true</c> if the timestamp is valid.</returns>
         public bool VerifyTimeTolerance(string timeStamp, long tolerance)
         {
-            return this.UnixTimeToDateTime(long.Parse(timeStamp)) >= DateTime.Now.AddSeconds(tolerance * -1);
+            long timestampMs;
+            try
+            {
+                timestampMs = long.Parse(timeStamp);
+            }
+            catch (Exception ex) when (ex is FormatException || ex is OverflowException || ex is ArgumentNullException)
+            {
+                throw new WorkOSWebhookException("Webhook timestamp is not a valid integer.");
+            }
+
+            try
+            {
+                return this.UnixTimeToDateTime(timestampMs) >= DateTime.Now.AddSeconds(tolerance * -1);
+            }
+            catch (Exception ex) when (ex is ArgumentOutOfRangeException || ex is OverflowException)
+            {
+                throw new WorkOSWebhookException("Webhook timestamp is out of representable range.");
+            }
         }
 
         /// <summary>

--- a/test/WorkOSTests/Services/Webhooks/ConstructEventTest.cs
+++ b/test/WorkOSTests/Services/Webhooks/ConstructEventTest.cs
@@ -83,7 +83,7 @@ namespace WorkOSTests
         public void ConstructEvent_MalformedHeader_Throws()
         {
             var service = new WebhookService();
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<WorkOSWebhookException>(
                 () => service.ConstructEvent(Payload, "garbage-header,without-components", Secret));
         }
     }


### PR DESCRIPTION
## Description

### Summary
- **Webhooks**: signature header now requires exactly two comma-separated parts before indexing, avoiding `IndexOutOfRangeException` on malformed input; malformed headers and timestamp parse errors surface as `WorkOSWebhookException`; timestamp tolerance check is symmetric (`Math.Abs(...)`) so far-future timestamps are rejected like too-old ones, matching `ActionsService.VerifyHeader`.
- **Session**: `ValidateJwt` now enforces token lifetime and accepted signing algorithms, defaulting to `RS256`. Issuer and audience validation are available through additive optional `ValidIssuer` / `ValidAudience` properties, but remain opt-in until the canonical WorkOS claim values are confirmed.
- **Client**: idempotency key is generated once in `MakeRawAPIRequest` before the retry loop instead of per-attempt in `CreateHttpRequestMessage`, so retried POSTs reuse the same key and server-side dedup actually works.
- **Vault**: `DecodeLeb128` is bounded to 4 continuation bytes and rejects truncated prefixes; `DecryptAsync` validates the decoded key length fits the remaining buffer before allocating, preventing ~4 GB allocations from pathological inputs.
- **Passwordless**: `sessionId` is wrapped with `Uri.EscapeDataString` in `SendSession`, matching every other generated service path and blocking path traversal / URL injection.

### Reviewer notes
- JWT issuer/audience enforcement is intentionally not enabled by default in this revision because the exact WorkOS access-token issuer/audience behavior still needs confirmation, especially for custom auth domains.
- This means the session change is an algorithm/lifetime hardening plus opt-in issuer/audience validation, not full default `iss`/`aud` enforcement.

### Test plan
- [ ] Webhooks: malformed signature header, non-numeric timestamp, and far-future timestamp all surface `WorkOSWebhookException`
- [ ] Session: JWT with wrong algorithm is rejected; `ValidIssuer` / `ValidAudience` / `ValidAlgorithms` overrides work as expected
- [ ] Client: retried POST under transient failure sends the same `Idempotency-Key` on every attempt
- [ ] Vault: malformed LEB128 prefix and oversized key-length claims fail cleanly without large allocations
- [ ] Passwordless: `SendSession` with a sessionId containing reserved URL chars hits the correctly-escaped path

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

Link to Devin session: https://app.devin.ai/sessions/eb5c055e7c324404990419c4a8f6f26d
Requested by: @gjtorikian